### PR TITLE
Fix misspell argv.verbose => argv.verbosity

### DIFF
--- a/samples/node/pub_sub/index.ts
+++ b/samples/node/pub_sub/index.ts
@@ -148,7 +148,7 @@ async function execute_session(connection: mqtt.MqttClientConnection, argv: Args
 }
 
 async function main(argv: Args) {
-    if (argv.verbose != 'none') {
+    if (argv.verbosity != 'none') {
         const level : io.LogLevel = parseInt(io.LogLevel[argv.verbosity.toUpperCase()]);
         io.enable_logging(level);
     }


### PR DESCRIPTION
Simple fix to a misspelled argument name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
