### PR TITLE
Update crt to 1.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,9 +70,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-crt": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.1.12.tgz",
-      "integrity": "sha512-to0nZvGeQJ+/aI6QFFTSkQpPHuzhz/NJigI5K+V58/ww9JJ6vDP9lwLYfwZRbuMvanYb5K8nMNX29cdIxR9UOQ==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.1.13.tgz",
+      "integrity": "sha512-gykbDKmtV34AFLMD5DITIDWcKEvUykb8bPeRSGxtGjo2UNSF/V6kU8gzaTXqtw6KeNZ6ALqOly7GiRR9zoMoWw==",
       "requires": {
         "axios": "^0.19.2",
         "cmake-js": "^6.1.0",
@@ -1269,9 +1269,9 @@
       "dev": true
     },
     "split2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.1.tgz",
+      "integrity": "sha512-wmX3JdfKWWghQSjezpJyMxlFodG/vNbV/Y9scsCqYSDWo0nCdteOdzqh8z1NDxpcIZB6BhkqWo6642VI/HA3oA==",
       "requires": {
         "readable-stream": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "aws-crt": "1.1.12"
+    "aws-crt": "1.1.13"
   }
 }


### PR DESCRIPTION
* Improves error handling by emitting error events on the process tick and not from a NAPI callback.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
