### PR TITLE
add note to samples readme about install from npm

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,6 +1,25 @@
 # Samples
 
+## Note
+
+If you are installed via npm instead of building from source, please make the following change to the package.json under each samples
+
+``` json
+From:
+    "dependencies": {
+        "aws-iot-device-sdk-v2": "../../../",
+        "yargs": "^14.0.0"
+    }
+
+To:
+    "dependencies": {
+        "aws-iot-device-sdk-v2":  "<latest released version eg: ^1.3.0>",
+        "yargs": "^14.0.0"
+    }
+```
+
 ## node/pub_sub
+
 This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
 for AWS IoT to send and receive messages

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,7 +2,7 @@
 
 ## Note
 
-If you are installed via npm instead of building from source, please make the following change to the package.json under each samples
+If you are installing via npm instead of building from source, please make the following change to the package.json under each sample.
 
 ``` json
 From:


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-iot-device-sdk-js-v2/issues/88
If you install the package via npm, the relative path will not work
However, we don't want to the version under the samples get behind of the current release.

*Description of changes:*
- Add note to README



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
