### PR TITLE
Improve README titles and add TOC to samples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS IoT SDK for Javascript v2
+# AWS IoT Device SDK for JavaScript v2
 This document provides information about the AWS IoT device SDK for Javascript V2.
 
 If you have any issues or feature requests, please file an issue or pull request.
@@ -27,7 +27,7 @@ to JS by the [awscrt](https://github.com/awslabs/aws-crt-nodejs) package.
 *   Node 10.x+
 
 ### Common Run Time
-The aws-crt package can be installed via npm 
+The aws-crt package can be installed via npm
 ```
 npm install aws-crt
 ```

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,4 +1,8 @@
-# Samples
+# Sample apps for the AWS IoT Device SDK for JavaScript v2
+
+* [pubsub](#nodepub_sub)
+* [fleet provisioning](#fleet-provisioning)
+* [basic discovery](#nodebasic_discovery)
 
 ## Note
 
@@ -80,11 +84,6 @@ and receive.
 </pre>
 </details>
 
-## node/basic_discovery
-
-This sample intended for use directly with the 
-[Getting Started with AWS IoT Greengrass](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html) guide.
-
 ## fleet provisioning
 
 This sample uses the AWS IoT
@@ -156,3 +155,8 @@ and receive.
 }
 </pre>
 </details>
+
+## node/basic_discovery
+
+This sample intended for use directly with the
+[Getting Started with AWS IoT Greengrass](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html) guide.


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:* Minor text-only edits to provide a smoother transition from the AWS IoT Core Developer Guide to the SDK documentation. (e.g. the links in https://docs.aws.amazon.com/iot/latest/developerguide/iot-connect-devices.html#iot-connect-device-sdks that land on an SDK README page.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
