### PR TITLE
Update to latest crt, fix dependencies in samples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,9 +99,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-crt": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.1.tgz",
-      "integrity": "sha512-D5Lt/qSXtZdOwMNlFLp1AebjBIztYIyh4PtIPoBqEApywyphfopKNUvOIwggrGEJVPl7lwfnejGMvgQ/6Jq1tw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.4.tgz",
+      "integrity": "sha512-tsipHWr3+JH/ZI5jrw+q92Eid61dl8NCYb8trSDUElPBRWfyNQolFGkGIJNxNoZDdrw4KWOjdmxXujT18LCSRg==",
       "requires": {
         "axios": "^0.19.2",
         "cmake-js": "^6.1.0",
@@ -135,9 +135,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -169,18 +169,6 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "bluebird": {
@@ -198,12 +186,12 @@
       }
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -233,6 +221,30 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "> 1.0.0 < 3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "camelcase": {
@@ -340,13 +352,13 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
       }
     },
@@ -359,15 +371,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
       "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -451,6 +454,30 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "ecc-jsbn": {
@@ -468,95 +495,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
-      },
-      "dependencies": {
-        "es6-symbol": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
-          }
-        }
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-        }
       }
     },
     "extend": {
@@ -698,6 +636,30 @@
         "remove-trailing-separator": "^1.0.1",
         "to-absolute-glob": "^2.0.0",
         "unique-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -765,9 +727,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1057,26 +1019,23 @@
       }
     },
     "mqtt": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.1.tgz",
-      "integrity": "sha512-Iv893r+jWlo5GkNcPOfCGwW8M49IixwHiKLFFYTociEymSibUVCORVEjPXWPGzSxhn7BdlUeHicbRmWiv0Crkg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.5.tgz",
+      "integrity": "sha512-l19iRa4en8qM19xYCsdkt2VWg/JPTQTUL0Gq//p1rRUSEBxywicylfGZQy4Ru2Pl/nN5gI0q5E66DIVybGSaRg==",
       "requires": {
-        "base64-js": "^1.3.0",
         "commist": "^1.0.0",
-        "concat-stream": "^1.6.2",
+        "concat-stream": "^2.0.0",
         "debug": "^4.1.1",
-        "end-of-stream": "^1.4.1",
-        "es6-map": "^0.1.5",
         "help-me": "^1.0.1",
         "inherits": "^2.0.3",
         "minimist": "^1.2.5",
-        "mqtt-packet": "^6.3.2",
+        "mqtt-packet": "^6.6.0",
         "pump": "^3.0.0",
-        "readable-stream": "^2.3.6",
+        "readable-stream": "^3.6.0",
         "reinterval": "^1.1.0",
         "split2": "^3.1.0",
         "ws": "^7.3.1",
-        "xtend": "^4.0.1"
+        "xtend": "^4.0.2"
       },
       "dependencies": {
         "debug": {
@@ -1130,11 +1089,6 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-    },
     "npmlog": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
@@ -1169,6 +1123,30 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "requires": {
         "readable-stream": "^2.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "os-locale": {
@@ -1268,17 +1246,13 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "rechoir": {
@@ -1387,18 +1361,6 @@
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
         "readable-stream": "^3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "splitargs": {
@@ -1438,11 +1400,18 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "strip-ansi": {
@@ -1479,6 +1448,30 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "through2-filter": {
@@ -1525,11 +1518,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -1709,6 +1697,28 @@
         "xtend": "^4.0.0"
       },
       "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "ws": {
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
@@ -1755,9 +1765,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "aws-crt": "1.3.1"
+    "aws-crt": "1.3.4"
   }
 }

--- a/samples/node/basic_discovery/package-lock.json
+++ b/samples/node/basic_discovery/package-lock.json
@@ -26,7 +26,7 @@
         "aws-iot-device-sdk-v2": {
             "version": "file:../../..",
             "requires": {
-                "aws-crt": "1.2.0"
+                "aws-crt": "1.3.4"
             },
             "dependencies": {
                 "@convergencelabs/typedoc-plugin-custom-modules": {
@@ -40,9 +40,9 @@
                     "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
                 },
                 "ajv": {
-                    "version": "6.12.4",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-                    "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "fast-json-stable-stringify": "^2.0.0",
@@ -122,15 +122,15 @@
                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 },
                 "aws-crt": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.2.0.tgz",
-                    "integrity": "sha512-B8KYjbz3HJvGrjK+cRtxgK0VPI1Dybe4DbvafunIzhpy2SD0pHxkQuvmgsFEuxYf3w+YkllA3VTJZ0tkxd43uQ==",
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.4.tgz",
+                    "integrity": "sha512-tsipHWr3+JH/ZI5jrw+q92Eid61dl8NCYb8trSDUElPBRWfyNQolFGkGIJNxNoZDdrw4KWOjdmxXujT18LCSRg==",
                     "requires": {
                         "axios": "^0.19.2",
                         "cmake-js": "^6.1.0",
                         "crypto-js": "^3.3.0",
-                        "fastestsmallesttextencoderdecoder": "^1.0.21",
-                        "mqtt": "^4.1.0",
+                        "fastestsmallesttextencoderdecoder": "^1.0.22",
+                        "mqtt": "^4.2.1",
                         "websocket-stream": "^5.5.2"
                     }
                 },
@@ -140,9 +140,9 @@
                     "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
                 },
                 "aws4": {
-                    "version": "1.10.1",
-                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-                    "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+                    "version": "1.11.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+                    "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
                 },
                 "axios": {
                     "version": "0.19.2",
@@ -158,9 +158,9 @@
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                 },
                 "base64-js": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-                    "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+                    "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.2",
@@ -185,9 +185,8 @@
                     }
                 },
                 "bl": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-                    "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+                    "version": "4.0.3",
+                    "resolved": "",
                     "requires": {
                         "buffer": "^5.5.0",
                         "inherits": "^2.0.4",
@@ -234,12 +233,12 @@
                     }
                 },
                 "buffer": {
-                    "version": "5.6.0",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
                     "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4"
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
                     }
                 },
                 "buffer-from": {
@@ -248,9 +247,9 @@
                     "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
                 },
                 "buffer-indexof-polyfill": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-                    "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+                    "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
                 },
                 "buffer-shims": {
                     "version": "1.0.0",
@@ -327,11 +326,11 @@
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
                         },
                         "ms": {
@@ -375,41 +374,37 @@
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 },
                 "concat-stream": {
-                    "version": "1.6.2",
-                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+                    "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
+                        "readable-stream": "^3.0.2",
                         "typedarray": "^0.0.6"
                     },
                     "dependencies": {
-                        "isarray": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                        },
                         "readable-stream": {
-                            "version": "2.3.7",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
                             }
                         },
+                        "safe-buffer": {
+                            "version": "5.2.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                        },
                         "string_decoder": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "~5.2.0"
                             }
                         }
                     }
@@ -424,21 +419,20 @@
                     "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
                     "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
                 },
-                "d": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-                    "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-                    "requires": {
-                        "es5-ext": "^0.10.50",
-                        "type": "^1.0.1"
-                    }
-                },
                 "dashdash": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                     "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                     "requires": {
                         "assert-plus": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
                     }
                 },
                 "decamelize": {
@@ -555,95 +549,6 @@
                         "once": "^1.4.0"
                     }
                 },
-                "es5-ext": {
-                    "version": "0.10.53",
-                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-                    "requires": {
-                        "es6-iterator": "~2.0.3",
-                        "es6-symbol": "~3.1.3",
-                        "next-tick": "~1.0.0"
-                    }
-                },
-                "es6-iterator": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-                    "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "^0.10.35",
-                        "es6-symbol": "^3.1.1"
-                    }
-                },
-                "es6-map": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-                    "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14",
-                        "es6-iterator": "~2.0.1",
-                        "es6-set": "~0.1.5",
-                        "es6-symbol": "~3.1.1",
-                        "event-emitter": "~0.3.5"
-                    }
-                },
-                "es6-set": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                    "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14",
-                        "es6-iterator": "~2.0.1",
-                        "es6-symbol": "3.1.1",
-                        "event-emitter": "~0.3.5"
-                    },
-                    "dependencies": {
-                        "es6-symbol": {
-                            "version": "3.1.1",
-                            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                            "requires": {
-                                "d": "1",
-                                "es5-ext": "~0.10.14"
-                            }
-                        }
-                    }
-                },
-                "es6-symbol": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-                    "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-                    "requires": {
-                        "d": "^1.0.1",
-                        "ext": "^1.1.2"
-                    }
-                },
-                "event-emitter": {
-                    "version": "0.3.5",
-                    "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-                    "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14"
-                    }
-                },
-                "ext": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-                    "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-                    "requires": {
-                        "type": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "type": {
-                            "version": "2.1.0",
-                            "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-                            "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-                        }
-                    }
-                },
                 "extend": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -675,21 +580,6 @@
                     "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
                     "requires": {
                         "debug": "=3.1.0"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                            "requires": {
-                                "ms": "2.0.0"
-                            }
-                        },
-                        "ms": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                        }
                     }
                 },
                 "forever-agent": {
@@ -892,9 +782,9 @@
                     }
                 },
                 "ieee754": {
-                    "version": "1.1.13",
-                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-                    "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
                 },
                 "inflight": {
                     "version": "1.0.6",
@@ -1104,29 +994,6 @@
                     "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
                     "requires": {
                         "readable-stream": "~1.0.26-2"
-                    },
-                    "dependencies": {
-                        "isarray": {
-                            "version": "0.0.1",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                        },
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
-                                "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                        }
                     }
                 },
                 "mime-db": {
@@ -1181,40 +1048,32 @@
                     }
                 },
                 "mqtt": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.0.tgz",
-                    "integrity": "sha512-CGMLigAKCp0hknWPM15yuZRbVrfQjZCG9Wn3GXDEfY2chDmUi5GT3UQ3OhTtMi7fELYb2s4Q/QiWv+dECQ7ZQg==",
+                    "version": "4.2.5",
+                    "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.5.tgz",
+                    "integrity": "sha512-l19iRa4en8qM19xYCsdkt2VWg/JPTQTUL0Gq//p1rRUSEBxywicylfGZQy4Ru2Pl/nN5gI0q5E66DIVybGSaRg==",
                     "requires": {
-                        "base64-js": "^1.3.0",
                         "commist": "^1.0.0",
-                        "concat-stream": "^1.6.2",
+                        "concat-stream": "^2.0.0",
                         "debug": "^4.1.1",
-                        "end-of-stream": "^1.4.1",
-                        "es6-map": "^0.1.5",
                         "help-me": "^1.0.1",
                         "inherits": "^2.0.3",
                         "minimist": "^1.2.5",
-                        "mqtt-packet": "^6.3.2",
+                        "mqtt-packet": "^6.6.0",
                         "pump": "^3.0.0",
-                        "readable-stream": "^2.3.6",
+                        "readable-stream": "^3.6.0",
                         "reinterval": "^1.1.0",
                         "split2": "^3.1.0",
                         "ws": "^7.3.1",
-                        "xtend": "^4.0.1"
+                        "xtend": "^4.0.2"
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
-                        },
-                        "isarray": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                         },
                         "ms": {
                             "version": "2.1.2",
@@ -1222,70 +1081,64 @@
                             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                         },
                         "readable-stream": {
-                            "version": "2.3.7",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
                             }
                         },
+                        "safe-buffer": {
+                            "version": "5.2.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                        },
                         "string_decoder": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "~5.2.0"
                             }
                         }
                     }
                 },
                 "mqtt-packet": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.4.0.tgz",
-                    "integrity": "sha512-dNd1RPyBolklOR27hgHhy3TxkDk31ZaDu4ljAgJoHlnVsdACH8guwEZhpk3ZMn6GAdH6ENDLgtE285FHIiXzxA==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.6.0.tgz",
+                    "integrity": "sha512-LvghnKMFC70hKWMVykmhJarlO5e7lT3t9s9A2qPCUx+lazL3Mq55U+eCV0eLi7/nRRQYvEUWo/2tTo89EjnCJQ==",
                     "requires": {
                         "bl": "^4.0.2",
                         "debug": "^4.1.1",
-                        "inherits": "^2.0.4",
-                        "process-nextick-args": "^2.0.1",
-                        "safe-buffer": "^5.2.1"
+                        "process-nextick-args": "^2.0.1"
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
                         },
                         "ms": {
                             "version": "2.1.2",
                             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                        },
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                         }
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 },
                 "neo-async": {
                     "version": "2.6.1",
                     "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
                     "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-                },
-                "next-tick": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-                    "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
                 },
                 "npmlog": {
                     "version": "1.2.1",
@@ -1737,11 +1590,6 @@
                     "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                     "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
                 },
-                "type": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-                    "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-                },
                 "typedarray": {
                     "version": "0.0.6",
                     "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -1861,18 +1709,13 @@
                                 "string_decoder": "~0.10.x",
                                 "util-deprecate": "~1.0.1"
                             }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         }
                     }
                 },
                 "uri-js": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-                    "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+                    "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -1987,9 +1830,9 @@
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "ws": {
-                    "version": "7.3.1",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-                    "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+                    "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
                 },
                 "xtend": {
                     "version": "4.0.2",

--- a/samples/node/fleet_provisioning/package-lock.json
+++ b/samples/node/fleet_provisioning/package-lock.json
@@ -21,7 +21,7 @@
         "aws-iot-device-sdk-v2": {
             "version": "file:../../..",
             "requires": {
-                "aws-crt": "1.2.0"
+                "aws-crt": "1.3.4"
             },
             "dependencies": {
                 "@convergencelabs/typedoc-plugin-custom-modules": {
@@ -35,9 +35,9 @@
                     "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
                 },
                 "ajv": {
-                    "version": "6.12.4",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-                    "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "fast-json-stable-stringify": "^2.0.0",
@@ -117,15 +117,15 @@
                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 },
                 "aws-crt": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.2.0.tgz",
-                    "integrity": "sha512-B8KYjbz3HJvGrjK+cRtxgK0VPI1Dybe4DbvafunIzhpy2SD0pHxkQuvmgsFEuxYf3w+YkllA3VTJZ0tkxd43uQ==",
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.4.tgz",
+                    "integrity": "sha512-tsipHWr3+JH/ZI5jrw+q92Eid61dl8NCYb8trSDUElPBRWfyNQolFGkGIJNxNoZDdrw4KWOjdmxXujT18LCSRg==",
                     "requires": {
                         "axios": "^0.19.2",
                         "cmake-js": "^6.1.0",
                         "crypto-js": "^3.3.0",
-                        "fastestsmallesttextencoderdecoder": "^1.0.21",
-                        "mqtt": "^4.1.0",
+                        "fastestsmallesttextencoderdecoder": "^1.0.22",
+                        "mqtt": "^4.2.1",
                         "websocket-stream": "^5.5.2"
                     }
                 },
@@ -135,9 +135,9 @@
                     "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
                 },
                 "aws4": {
-                    "version": "1.10.1",
-                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-                    "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+                    "version": "1.11.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+                    "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
                 },
                 "axios": {
                     "version": "0.19.2",
@@ -153,9 +153,9 @@
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                 },
                 "base64-js": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-                    "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+                    "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.2",
@@ -180,9 +180,8 @@
                     }
                 },
                 "bl": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-                    "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+                    "version": "4.0.3",
+                    "resolved": "",
                     "requires": {
                         "buffer": "^5.5.0",
                         "inherits": "^2.0.4",
@@ -229,12 +228,12 @@
                     }
                 },
                 "buffer": {
-                    "version": "5.6.0",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
                     "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4"
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
                     }
                 },
                 "buffer-from": {
@@ -243,9 +242,9 @@
                     "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
                 },
                 "buffer-indexof-polyfill": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-                    "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+                    "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
                 },
                 "buffer-shims": {
                     "version": "1.0.0",
@@ -322,11 +321,11 @@
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
                         },
                         "ms": {
@@ -370,41 +369,37 @@
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 },
                 "concat-stream": {
-                    "version": "1.6.2",
-                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+                    "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
+                        "readable-stream": "^3.0.2",
                         "typedarray": "^0.0.6"
                     },
                     "dependencies": {
-                        "isarray": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                        },
                         "readable-stream": {
-                            "version": "2.3.7",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
                             }
                         },
+                        "safe-buffer": {
+                            "version": "5.2.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                        },
                         "string_decoder": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "~5.2.0"
                             }
                         }
                     }
@@ -419,21 +414,20 @@
                     "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
                     "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
                 },
-                "d": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-                    "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-                    "requires": {
-                        "es5-ext": "^0.10.50",
-                        "type": "^1.0.1"
-                    }
-                },
                 "dashdash": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                     "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                     "requires": {
                         "assert-plus": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
                     }
                 },
                 "decamelize": {
@@ -550,95 +544,6 @@
                         "once": "^1.4.0"
                     }
                 },
-                "es5-ext": {
-                    "version": "0.10.53",
-                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-                    "requires": {
-                        "es6-iterator": "~2.0.3",
-                        "es6-symbol": "~3.1.3",
-                        "next-tick": "~1.0.0"
-                    }
-                },
-                "es6-iterator": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-                    "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "^0.10.35",
-                        "es6-symbol": "^3.1.1"
-                    }
-                },
-                "es6-map": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-                    "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14",
-                        "es6-iterator": "~2.0.1",
-                        "es6-set": "~0.1.5",
-                        "es6-symbol": "~3.1.1",
-                        "event-emitter": "~0.3.5"
-                    }
-                },
-                "es6-set": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                    "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14",
-                        "es6-iterator": "~2.0.1",
-                        "es6-symbol": "3.1.1",
-                        "event-emitter": "~0.3.5"
-                    },
-                    "dependencies": {
-                        "es6-symbol": {
-                            "version": "3.1.1",
-                            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                            "requires": {
-                                "d": "1",
-                                "es5-ext": "~0.10.14"
-                            }
-                        }
-                    }
-                },
-                "es6-symbol": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-                    "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-                    "requires": {
-                        "d": "^1.0.1",
-                        "ext": "^1.1.2"
-                    }
-                },
-                "event-emitter": {
-                    "version": "0.3.5",
-                    "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-                    "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14"
-                    }
-                },
-                "ext": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-                    "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-                    "requires": {
-                        "type": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "type": {
-                            "version": "2.1.0",
-                            "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-                            "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-                        }
-                    }
-                },
                 "extend": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -670,21 +575,6 @@
                     "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
                     "requires": {
                         "debug": "=3.1.0"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                            "requires": {
-                                "ms": "2.0.0"
-                            }
-                        },
-                        "ms": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                        }
                     }
                 },
                 "forever-agent": {
@@ -887,9 +777,9 @@
                     }
                 },
                 "ieee754": {
-                    "version": "1.1.13",
-                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-                    "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
                 },
                 "inflight": {
                     "version": "1.0.6",
@@ -1099,29 +989,6 @@
                     "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
                     "requires": {
                         "readable-stream": "~1.0.26-2"
-                    },
-                    "dependencies": {
-                        "isarray": {
-                            "version": "0.0.1",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                        },
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
-                                "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                        }
                     }
                 },
                 "mime-db": {
@@ -1176,40 +1043,32 @@
                     }
                 },
                 "mqtt": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.0.tgz",
-                    "integrity": "sha512-CGMLigAKCp0hknWPM15yuZRbVrfQjZCG9Wn3GXDEfY2chDmUi5GT3UQ3OhTtMi7fELYb2s4Q/QiWv+dECQ7ZQg==",
+                    "version": "4.2.5",
+                    "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.5.tgz",
+                    "integrity": "sha512-l19iRa4en8qM19xYCsdkt2VWg/JPTQTUL0Gq//p1rRUSEBxywicylfGZQy4Ru2Pl/nN5gI0q5E66DIVybGSaRg==",
                     "requires": {
-                        "base64-js": "^1.3.0",
                         "commist": "^1.0.0",
-                        "concat-stream": "^1.6.2",
+                        "concat-stream": "^2.0.0",
                         "debug": "^4.1.1",
-                        "end-of-stream": "^1.4.1",
-                        "es6-map": "^0.1.5",
                         "help-me": "^1.0.1",
                         "inherits": "^2.0.3",
                         "minimist": "^1.2.5",
-                        "mqtt-packet": "^6.3.2",
+                        "mqtt-packet": "^6.6.0",
                         "pump": "^3.0.0",
-                        "readable-stream": "^2.3.6",
+                        "readable-stream": "^3.6.0",
                         "reinterval": "^1.1.0",
                         "split2": "^3.1.0",
                         "ws": "^7.3.1",
-                        "xtend": "^4.0.1"
+                        "xtend": "^4.0.2"
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
-                        },
-                        "isarray": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                         },
                         "ms": {
                             "version": "2.1.2",
@@ -1217,70 +1076,64 @@
                             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                         },
                         "readable-stream": {
-                            "version": "2.3.7",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
                             }
                         },
+                        "safe-buffer": {
+                            "version": "5.2.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                        },
                         "string_decoder": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "~5.2.0"
                             }
                         }
                     }
                 },
                 "mqtt-packet": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.4.0.tgz",
-                    "integrity": "sha512-dNd1RPyBolklOR27hgHhy3TxkDk31ZaDu4ljAgJoHlnVsdACH8guwEZhpk3ZMn6GAdH6ENDLgtE285FHIiXzxA==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.6.0.tgz",
+                    "integrity": "sha512-LvghnKMFC70hKWMVykmhJarlO5e7lT3t9s9A2qPCUx+lazL3Mq55U+eCV0eLi7/nRRQYvEUWo/2tTo89EjnCJQ==",
                     "requires": {
                         "bl": "^4.0.2",
                         "debug": "^4.1.1",
-                        "inherits": "^2.0.4",
-                        "process-nextick-args": "^2.0.1",
-                        "safe-buffer": "^5.2.1"
+                        "process-nextick-args": "^2.0.1"
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
                         },
                         "ms": {
                             "version": "2.1.2",
                             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                        },
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                         }
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 },
                 "neo-async": {
                     "version": "2.6.1",
                     "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
                     "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-                },
-                "next-tick": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-                    "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
                 },
                 "npmlog": {
                     "version": "1.2.1",
@@ -1732,11 +1585,6 @@
                     "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                     "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
                 },
-                "type": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-                    "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-                },
                 "typedarray": {
                     "version": "0.0.6",
                     "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -1856,18 +1704,13 @@
                                 "string_decoder": "~0.10.x",
                                 "util-deprecate": "~1.0.1"
                             }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         }
                     }
                 },
                 "uri-js": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-                    "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+                    "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -1982,9 +1825,9 @@
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "ws": {
-                    "version": "7.3.1",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-                    "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+                    "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
                 },
                 "xtend": {
                     "version": "4.0.2",

--- a/samples/node/pub_sub/package-lock.json
+++ b/samples/node/pub_sub/package-lock.json
@@ -26,7 +26,7 @@
         "aws-iot-device-sdk-v2": {
             "version": "file:../../..",
             "requires": {
-                "aws-crt": "1.2.0"
+                "aws-crt": "1.3.4"
             },
             "dependencies": {
                 "@convergencelabs/typedoc-plugin-custom-modules": {
@@ -40,9 +40,9 @@
                     "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
                 },
                 "ajv": {
-                    "version": "6.12.4",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-                    "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "fast-json-stable-stringify": "^2.0.0",
@@ -122,15 +122,15 @@
                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 },
                 "aws-crt": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.2.0.tgz",
-                    "integrity": "sha512-B8KYjbz3HJvGrjK+cRtxgK0VPI1Dybe4DbvafunIzhpy2SD0pHxkQuvmgsFEuxYf3w+YkllA3VTJZ0tkxd43uQ==",
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.4.tgz",
+                    "integrity": "sha512-tsipHWr3+JH/ZI5jrw+q92Eid61dl8NCYb8trSDUElPBRWfyNQolFGkGIJNxNoZDdrw4KWOjdmxXujT18LCSRg==",
                     "requires": {
                         "axios": "^0.19.2",
                         "cmake-js": "^6.1.0",
                         "crypto-js": "^3.3.0",
-                        "fastestsmallesttextencoderdecoder": "^1.0.21",
-                        "mqtt": "^4.1.0",
+                        "fastestsmallesttextencoderdecoder": "^1.0.22",
+                        "mqtt": "^4.2.1",
                         "websocket-stream": "^5.5.2"
                     }
                 },
@@ -140,9 +140,9 @@
                     "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
                 },
                 "aws4": {
-                    "version": "1.10.1",
-                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-                    "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+                    "version": "1.11.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+                    "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
                 },
                 "axios": {
                     "version": "0.19.2",
@@ -158,9 +158,9 @@
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                 },
                 "base64-js": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-                    "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+                    "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.2",
@@ -185,9 +185,8 @@
                     }
                 },
                 "bl": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-                    "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+                    "version": "4.0.3",
+                    "resolved": "",
                     "requires": {
                         "buffer": "^5.5.0",
                         "inherits": "^2.0.4",
@@ -234,12 +233,12 @@
                     }
                 },
                 "buffer": {
-                    "version": "5.6.0",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-                    "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
                     "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4"
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
                     }
                 },
                 "buffer-from": {
@@ -248,9 +247,9 @@
                     "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
                 },
                 "buffer-indexof-polyfill": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-                    "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+                    "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
                 },
                 "buffer-shims": {
                     "version": "1.0.0",
@@ -327,11 +326,11 @@
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
                         },
                         "ms": {
@@ -375,41 +374,37 @@
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 },
                 "concat-stream": {
-                    "version": "1.6.2",
-                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+                    "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
+                        "readable-stream": "^3.0.2",
                         "typedarray": "^0.0.6"
                     },
                     "dependencies": {
-                        "isarray": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                        },
                         "readable-stream": {
-                            "version": "2.3.7",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
                             }
                         },
+                        "safe-buffer": {
+                            "version": "5.2.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                        },
                         "string_decoder": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "~5.2.0"
                             }
                         }
                     }
@@ -424,21 +419,20 @@
                     "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
                     "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
                 },
-                "d": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-                    "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-                    "requires": {
-                        "es5-ext": "^0.10.50",
-                        "type": "^1.0.1"
-                    }
-                },
                 "dashdash": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                     "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                     "requires": {
                         "assert-plus": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
                     }
                 },
                 "decamelize": {
@@ -555,95 +549,6 @@
                         "once": "^1.4.0"
                     }
                 },
-                "es5-ext": {
-                    "version": "0.10.53",
-                    "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-                    "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-                    "requires": {
-                        "es6-iterator": "~2.0.3",
-                        "es6-symbol": "~3.1.3",
-                        "next-tick": "~1.0.0"
-                    }
-                },
-                "es6-iterator": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-                    "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "^0.10.35",
-                        "es6-symbol": "^3.1.1"
-                    }
-                },
-                "es6-map": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-                    "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14",
-                        "es6-iterator": "~2.0.1",
-                        "es6-set": "~0.1.5",
-                        "es6-symbol": "~3.1.1",
-                        "event-emitter": "~0.3.5"
-                    }
-                },
-                "es6-set": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                    "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14",
-                        "es6-iterator": "~2.0.1",
-                        "es6-symbol": "3.1.1",
-                        "event-emitter": "~0.3.5"
-                    },
-                    "dependencies": {
-                        "es6-symbol": {
-                            "version": "3.1.1",
-                            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                            "requires": {
-                                "d": "1",
-                                "es5-ext": "~0.10.14"
-                            }
-                        }
-                    }
-                },
-                "es6-symbol": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-                    "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-                    "requires": {
-                        "d": "^1.0.1",
-                        "ext": "^1.1.2"
-                    }
-                },
-                "event-emitter": {
-                    "version": "0.3.5",
-                    "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-                    "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-                    "requires": {
-                        "d": "1",
-                        "es5-ext": "~0.10.14"
-                    }
-                },
-                "ext": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-                    "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-                    "requires": {
-                        "type": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "type": {
-                            "version": "2.1.0",
-                            "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-                            "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
-                        }
-                    }
-                },
                 "extend": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -675,21 +580,6 @@
                     "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
                     "requires": {
                         "debug": "=3.1.0"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                            "requires": {
-                                "ms": "2.0.0"
-                            }
-                        },
-                        "ms": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                        }
                     }
                 },
                 "forever-agent": {
@@ -892,9 +782,9 @@
                     }
                 },
                 "ieee754": {
-                    "version": "1.1.13",
-                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-                    "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
                 },
                 "inflight": {
                     "version": "1.0.6",
@@ -1104,29 +994,6 @@
                     "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
                     "requires": {
                         "readable-stream": "~1.0.26-2"
-                    },
-                    "dependencies": {
-                        "isarray": {
-                            "version": "0.0.1",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                        },
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
-                                "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                        }
                     }
                 },
                 "mime-db": {
@@ -1181,40 +1048,32 @@
                     }
                 },
                 "mqtt": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.0.tgz",
-                    "integrity": "sha512-CGMLigAKCp0hknWPM15yuZRbVrfQjZCG9Wn3GXDEfY2chDmUi5GT3UQ3OhTtMi7fELYb2s4Q/QiWv+dECQ7ZQg==",
+                    "version": "4.2.5",
+                    "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.5.tgz",
+                    "integrity": "sha512-l19iRa4en8qM19xYCsdkt2VWg/JPTQTUL0Gq//p1rRUSEBxywicylfGZQy4Ru2Pl/nN5gI0q5E66DIVybGSaRg==",
                     "requires": {
-                        "base64-js": "^1.3.0",
                         "commist": "^1.0.0",
-                        "concat-stream": "^1.6.2",
+                        "concat-stream": "^2.0.0",
                         "debug": "^4.1.1",
-                        "end-of-stream": "^1.4.1",
-                        "es6-map": "^0.1.5",
                         "help-me": "^1.0.1",
                         "inherits": "^2.0.3",
                         "minimist": "^1.2.5",
-                        "mqtt-packet": "^6.3.2",
+                        "mqtt-packet": "^6.6.0",
                         "pump": "^3.0.0",
-                        "readable-stream": "^2.3.6",
+                        "readable-stream": "^3.6.0",
                         "reinterval": "^1.1.0",
                         "split2": "^3.1.0",
                         "ws": "^7.3.1",
-                        "xtend": "^4.0.1"
+                        "xtend": "^4.0.2"
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
-                        },
-                        "isarray": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                         },
                         "ms": {
                             "version": "2.1.2",
@@ -1222,70 +1081,64 @@
                             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                         },
                         "readable-stream": {
-                            "version": "2.3.7",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
                             }
                         },
+                        "safe-buffer": {
+                            "version": "5.2.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                        },
                         "string_decoder": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "~5.2.0"
                             }
                         }
                     }
                 },
                 "mqtt-packet": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.4.0.tgz",
-                    "integrity": "sha512-dNd1RPyBolklOR27hgHhy3TxkDk31ZaDu4ljAgJoHlnVsdACH8guwEZhpk3ZMn6GAdH6ENDLgtE285FHIiXzxA==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.6.0.tgz",
+                    "integrity": "sha512-LvghnKMFC70hKWMVykmhJarlO5e7lT3t9s9A2qPCUx+lazL3Mq55U+eCV0eLi7/nRRQYvEUWo/2tTo89EjnCJQ==",
                     "requires": {
                         "bl": "^4.0.2",
                         "debug": "^4.1.1",
-                        "inherits": "^2.0.4",
-                        "process-nextick-args": "^2.0.1",
-                        "safe-buffer": "^5.2.1"
+                        "process-nextick-args": "^2.0.1"
                     },
                     "dependencies": {
                         "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                            "version": "4.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                             "requires": {
-                                "ms": "^2.1.1"
+                                "ms": "2.1.2"
                             }
                         },
                         "ms": {
                             "version": "2.1.2",
                             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                        },
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                         }
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 },
                 "neo-async": {
                     "version": "2.6.1",
                     "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
                     "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-                },
-                "next-tick": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-                    "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
                 },
                 "npmlog": {
                     "version": "1.2.1",
@@ -1737,11 +1590,6 @@
                     "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                     "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
                 },
-                "type": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-                    "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-                },
                 "typedarray": {
                     "version": "0.0.6",
                     "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -1861,18 +1709,13 @@
                                 "string_decoder": "~0.10.x",
                                 "util-deprecate": "~1.0.1"
                             }
-                        },
-                        "string_decoder": {
-                            "version": "0.10.31",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         }
                     }
                 },
                 "uri-js": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-                    "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+                    "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -1987,9 +1830,9 @@
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "ws": {
-                    "version": "7.3.1",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-                    "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+                    "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
                 },
                 "xtend": {
                     "version": "4.0.2",


### PR DESCRIPTION
* Fixes crash invoking Openssl APIs when there's a mismatch between node's openssl and the openssl the sdk was built against
* Fixes crash on shutdown due to not waiting for thread-based C objects to completely destroy themselves.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
