### PR TITLE
Fix parameter name for CA file in pub-sub sample README

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -38,7 +38,7 @@ Source: `samples/node/pub_sub`
 Run the sample like this:
 ```
 npm install
-node dist/index.js --endpoint <endpoint> --root-ca <file> --cert <file> --key <file>
+node dist/index.js --endpoint <endpoint> --ca_file <file> --cert <file> --key <file>
 ```
 
 Your Thing's


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes the parameter name for CA file in pub-sub sample README from `root-ca` to `ca_file`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
