### PR TITLE
Update aws-crt, fixes MQTT websocket reconnect crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,9 +99,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-crt": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.7.tgz",
-      "integrity": "sha512-20MgLc1DoYma5y2ogcCB3ee+no130JCZ8/vY6b5qCvfbcJjgX6tdhJVOWAXPtz1EafLoJLwWRC5/VVywVQgIhQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.8.tgz",
+      "integrity": "sha512-8jsUivq90pOu8HVLb/EKNaeZqJIBDzmhCIDB6WG+SpsTvplG5vqp1Q5wzHzByynqzBkHNCzQK4MN1wN6ZDFvng==",
       "requires": {
         "axios": "^0.21.1",
         "cmake-js": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "aws-crt": "1.3.7"
+    "aws-crt": "1.3.8"
   }
 }


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
