### PR TITLE
MQTT fixes and improvements via aws-crt update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
-      "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
+      "version": "10.17.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+      "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==",
       "dev": true
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -99,15 +99,15 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-crt": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.8.tgz",
-      "integrity": "sha512-8jsUivq90pOu8HVLb/EKNaeZqJIBDzmhCIDB6WG+SpsTvplG5vqp1Q5wzHzByynqzBkHNCzQK4MN1wN6ZDFvng==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.5.1.tgz",
+      "integrity": "sha512-SkipCfrN50TCGE8RKEemsDCIJMHtP56ryWumSW1pDVRHO4/++nVdWu0UTD0JNIb6DOFmXv5yj7tFRixHMChz3Q==",
       "requires": {
         "axios": "^0.21.1",
         "cmake-js": "^6.1.0",
         "crypto-js": "^3.3.0",
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "mqtt": "^4.2.1",
+        "mqtt": "^4.2.6",
         "websocket-stream": "^5.5.2"
       }
     },
@@ -117,9 +117,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
       "version": "0.21.1",
@@ -162,13 +162,38 @@
       }
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "bluebird": {
@@ -200,9 +225,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-      "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -221,30 +246,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "> 1.0.0 < 3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "camelcase": {
@@ -300,21 +301,6 @@
         "url-join": "0",
         "which": "^1.0.9",
         "yargs": "^3.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "code-point-at": {
@@ -353,6 +339,31 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "core-util-is": {
@@ -449,6 +460,11 @@
         "stream-shift": "^1.0.0"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -516,9 +532,9 @@
       "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -634,6 +650,11 @@
         "unique-stream": "^2.0.2"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -659,14 +680,14 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -716,9 +737,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==",
       "dev": true
     },
     "http-signature": {
@@ -842,9 +863,9 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -956,42 +977,19 @@
       "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
       "requires": {
         "readable-stream": "~1.0.26-2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.46.0"
       }
     },
     "minimatch": {
@@ -1050,12 +1048,37 @@
         "split2": "^3.1.0",
         "ws": "^7.3.1",
         "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "mqtt-packet": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.7.0.tgz",
-      "integrity": "sha512-GzgeeCirQpB59FyhHvf8BLiIYgxctPSxuSyaF2vWnkt7paX7jtuQ8Gpl+DkHCxZmYuv7GQE6zcUAegpafd0MqQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.8.1.tgz",
+      "integrity": "sha512-XM+QN6/pNVvoTSAiaOCuOSy8AVau6/8LVdLyMhvv2wJqzJjp8IL/h4R+wTcfm+CV+HhL6i826pHqDTCCKyBdyA==",
       "requires": {
         "bl": "^4.0.2",
         "debug": "^4.1.1",
@@ -1109,6 +1132,11 @@
         "readable-stream": "^2.0.1"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1230,13 +1258,14 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "rechoir": {
@@ -1286,12 +1315,12 @@
       }
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -1346,6 +1375,31 @@
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
         "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "splitargs": {
@@ -1385,19 +1439,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
-      }
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -1435,6 +1479,11 @@
         "xtend": "~4.0.1"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1550,15 +1599,15 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.4.tgz",
-      "integrity": "sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==",
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
       "dev": true,
       "optional": true
     },
@@ -1625,18 +1674,13 @@
             "string_decoder": "~0.10.x",
             "util-deprecate": "~1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -1679,6 +1723,11 @@
         "xtend": "^4.0.0"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1747,9 +1796,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -1757,9 +1806,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "aws-crt": "1.3.8"
+    "aws-crt": "1.5.1"
   }
 }

--- a/samples/node/basic_discovery/index.ts
+++ b/samples/node/basic_discovery/index.ts
@@ -147,9 +147,9 @@ async function execute_session(connection: mqtt.MqttClientConnection, argv: Args
         try {
             const decoder = new TextDecoder('utf8');
             if (argv.mode == 'both' || argv.mode == 'subscribe') {
-                const on_publish = (topic: string, payload: ArrayBuffer) => {
+                const on_publish = (topic: string, payload: ArrayBuffer, dup: boolean, qos: mqtt.QoS, retain: boolean) => {
                     const json = decoder.decode(payload);
-                    console.log(`Publish received on topic ${topic}`);
+                    console.log(`Publish received. topic:"${topic}" dup:${dup} qos:${qos} retain:${retain}`);
                     console.log(json);
                     const message = JSON.parse(json);
                     if (message.sequence == argv.max_pub_ops) {

--- a/samples/node/basic_discovery/package-lock.json
+++ b/samples/node/basic_discovery/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@types/node": {
-            "version": "10.17.50",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
-            "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
+            "version": "10.17.54",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+            "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==",
             "dev": true
         },
         "ansi-regex": {
@@ -26,7 +26,7 @@
         "aws-iot-device-sdk-v2": {
             "version": "file:../../..",
             "requires": {
-                "aws-crt": "1.3.7"
+                "aws-crt": "1.5.1"
             },
             "dependencies": {
                 "@convergencelabs/typedoc-plugin-custom-modules": {
@@ -35,9 +35,9 @@
                     "integrity": "sha512-SbQ+YqdMh5nRKBDNWvVx9Hvq8xaZEDJoG98qwuWS/udrm3bK1yAwmwqt5vWwtiaDYZoUXEWro1EbxcCDU7V56w=="
                 },
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-                    "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+                    "version": "10.17.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+                    "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ=="
                 },
                 "ajv": {
                     "version": "6.12.6",
@@ -122,15 +122,15 @@
                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 },
                 "aws-crt": {
-                    "version": "1.3.7",
-                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.7.tgz",
-                    "integrity": "sha512-20MgLc1DoYma5y2ogcCB3ee+no130JCZ8/vY6b5qCvfbcJjgX6tdhJVOWAXPtz1EafLoJLwWRC5/VVywVQgIhQ==",
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.5.1.tgz",
+                    "integrity": "sha512-SkipCfrN50TCGE8RKEemsDCIJMHtP56ryWumSW1pDVRHO4/++nVdWu0UTD0JNIb6DOFmXv5yj7tFRixHMChz3Q==",
                     "requires": {
                         "axios": "^0.21.1",
                         "cmake-js": "^6.1.0",
                         "crypto-js": "^3.3.0",
                         "fastestsmallesttextencoderdecoder": "^1.0.22",
-                        "mqtt": "^4.2.1",
+                        "mqtt": "^4.2.6",
                         "websocket-stream": "^5.5.2"
                     }
                 },
@@ -185,9 +185,9 @@
                     }
                 },
                 "bl": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-                    "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+                    "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
                     "requires": {
                         "buffer": "^5.5.0",
                         "inherits": "^2.0.4",
@@ -338,12 +338,6 @@
                     "requires": {
                         "delayed-stream": "~1.0.0"
                     }
-                },
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "optional": true
                 },
                 "commist": {
                     "version": "1.1.0",
@@ -561,9 +555,9 @@
                     "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
                 },
                 "follow-redirects": {
-                    "version": "1.13.1",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-                    "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+                    "version": "1.13.2",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+                    "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
                 },
                 "forever-agent": {
                     "version": "0.6.1",
@@ -613,6 +607,11 @@
                         "mkdirp": ">=0.5 0",
                         "rimraf": "2"
                     }
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
                 },
                 "gauge": {
                     "version": "1.2.7",
@@ -703,14 +702,14 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.2.4",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+                    "version": "4.2.6",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
                 },
                 "handlebars": {
-                    "version": "4.7.6",
-                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-                    "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+                    "version": "4.7.7",
+                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+                    "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
                     "requires": {
                         "minimist": "^1.2.5",
                         "neo-async": "^2.6.0",
@@ -733,6 +732,14 @@
                         "har-schema": "^2.0.0"
                     }
                 },
+                "has": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
                 "has-unicode": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -750,9 +757,9 @@
                     }
                 },
                 "highlight.js": {
-                    "version": "10.0.3",
-                    "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
-                    "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ=="
+                    "version": "10.6.0",
+                    "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+                    "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
                 },
                 "http-signature": {
                     "version": "1.2.0",
@@ -789,9 +796,9 @@
                     "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
                 },
                 "interpret": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-                    "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
                 },
                 "invert-kv": {
                     "version": "1.0.0",
@@ -805,6 +812,14 @@
                     "requires": {
                         "is-relative": "^1.0.0",
                         "is-windows": "^1.0.1"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+                    "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+                    "requires": {
+                        "has": "^1.0.3"
                     }
                 },
                 "is-extglob": {
@@ -962,9 +977,9 @@
                     "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
                 },
                 "lunr": {
-                    "version": "2.3.8",
-                    "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-                    "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
+                    "version": "2.3.9",
+                    "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+                    "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
                 },
                 "marked": {
                     "version": "1.0.0",
@@ -980,16 +995,16 @@
                     }
                 },
                 "mime-db": {
-                    "version": "1.45.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-                    "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+                    "version": "1.46.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+                    "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
                 },
                 "mime-types": {
-                    "version": "2.1.28",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-                    "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+                    "version": "2.1.29",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+                    "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
                     "requires": {
-                        "mime-db": "1.45.0"
+                        "mime-db": "1.46.0"
                     }
                 },
                 "minimatch": {
@@ -1076,9 +1091,9 @@
                     }
                 },
                 "mqtt-packet": {
-                    "version": "6.7.0",
-                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.7.0.tgz",
-                    "integrity": "sha512-GzgeeCirQpB59FyhHvf8BLiIYgxctPSxuSyaF2vWnkt7paX7jtuQ8Gpl+DkHCxZmYuv7GQE6zcUAegpafd0MqQ==",
+                    "version": "6.8.1",
+                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.8.1.tgz",
+                    "integrity": "sha512-XM+QN6/pNVvoTSAiaOCuOSy8AVau6/8LVdLyMhvv2wJqzJjp8IL/h4R+wTcfm+CV+HhL6i826pHqDTCCKyBdyA==",
                     "requires": {
                         "bl": "^4.0.2",
                         "debug": "^4.1.1",
@@ -1091,9 +1106,9 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "neo-async": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-                    "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+                    "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
                 },
                 "npmlog": {
                     "version": "1.2.1",
@@ -1311,10 +1326,11 @@
                     }
                 },
                 "resolve": {
-                    "version": "1.17.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+                    "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
                     "requires": {
+                        "is-core-module": "^2.2.0",
                         "path-parse": "^1.0.6"
                     }
                 },
@@ -1551,9 +1567,9 @@
                     "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                 },
                 "typedoc": {
-                    "version": "0.17.7",
-                    "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
-                    "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
+                    "version": "0.17.8",
+                    "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+                    "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
                     "requires": {
                         "fs-extra": "^8.1.0",
                         "handlebars": "^4.7.6",
@@ -1564,7 +1580,7 @@
                         "minimatch": "^3.0.0",
                         "progress": "^2.0.3",
                         "shelljs": "^0.8.4",
-                        "typedoc-default-themes": "^0.10.1"
+                        "typedoc-default-themes": "^0.10.2"
                     },
                     "dependencies": {
                         "fs-extra": {
@@ -1580,26 +1596,23 @@
                     }
                 },
                 "typedoc-default-themes": {
-                    "version": "0.10.1",
-                    "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz",
-                    "integrity": "sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==",
+                    "version": "0.10.2",
+                    "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+                    "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
                     "requires": {
                         "lunr": "^2.3.8"
                     }
                 },
                 "typescript": {
-                    "version": "3.9.3",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-                    "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ=="
+                    "version": "3.9.9",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+                    "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
                 },
                 "uglify-js": {
-                    "version": "3.9.3",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
-                    "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
-                    "optional": true,
-                    "requires": {
-                        "commander": "~2.20.3"
-                    }
+                    "version": "3.12.8",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+                    "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+                    "optional": true
                 },
                 "ultron": {
                     "version": "1.1.1",
@@ -1668,9 +1681,9 @@
                     }
                 },
                 "uri-js": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-                    "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+                    "version": "4.4.1",
+                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+                    "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -1785,9 +1798,9 @@
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "ws": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-                    "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+                    "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
                 },
                 "xtend": {
                     "version": "4.0.2",
@@ -1945,9 +1958,9 @@
             }
         },
         "typescript": {
-            "version": "3.9.7",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
             "dev": true
         },
         "which-module": {
@@ -1966,9 +1979,9 @@
             }
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
         },
         "yargs": {
             "version": "14.2.3",

--- a/samples/node/fleet_provisioning/package-lock.json
+++ b/samples/node/fleet_provisioning/package-lock.json
@@ -5,10 +5,15 @@
     "requires": true,
     "dependencies": {
         "@types/node": {
-            "version": "10.17.50",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
-            "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
+            "version": "10.17.54",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+            "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==",
             "dev": true
+        },
+        "ansi-regex": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -21,7 +26,7 @@
         "aws-iot-device-sdk-v2": {
             "version": "file:../../..",
             "requires": {
-                "aws-crt": "1.3.7"
+                "aws-crt": "1.5.1"
             },
             "dependencies": {
                 "@convergencelabs/typedoc-plugin-custom-modules": {
@@ -30,9 +35,9 @@
                     "integrity": "sha512-SbQ+YqdMh5nRKBDNWvVx9Hvq8xaZEDJoG98qwuWS/udrm3bK1yAwmwqt5vWwtiaDYZoUXEWro1EbxcCDU7V56w=="
                 },
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-                    "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+                    "version": "10.17.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+                    "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ=="
                 },
                 "ajv": {
                     "version": "6.12.6",
@@ -117,15 +122,15 @@
                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 },
                 "aws-crt": {
-                    "version": "1.3.7",
-                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.7.tgz",
-                    "integrity": "sha512-20MgLc1DoYma5y2ogcCB3ee+no130JCZ8/vY6b5qCvfbcJjgX6tdhJVOWAXPtz1EafLoJLwWRC5/VVywVQgIhQ==",
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.5.1.tgz",
+                    "integrity": "sha512-SkipCfrN50TCGE8RKEemsDCIJMHtP56ryWumSW1pDVRHO4/++nVdWu0UTD0JNIb6DOFmXv5yj7tFRixHMChz3Q==",
                     "requires": {
                         "axios": "^0.21.1",
                         "cmake-js": "^6.1.0",
                         "crypto-js": "^3.3.0",
                         "fastestsmallesttextencoderdecoder": "^1.0.22",
-                        "mqtt": "^4.2.1",
+                        "mqtt": "^4.2.6",
                         "websocket-stream": "^5.5.2"
                     }
                 },
@@ -180,9 +185,9 @@
                     }
                 },
                 "bl": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-                    "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+                    "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
                     "requires": {
                         "buffer": "^5.5.0",
                         "inherits": "^2.0.4",
@@ -333,12 +338,6 @@
                     "requires": {
                         "delayed-stream": "~1.0.0"
                     }
-                },
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "optional": true
                 },
                 "commist": {
                     "version": "1.1.0",
@@ -556,9 +555,9 @@
                     "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
                 },
                 "follow-redirects": {
-                    "version": "1.13.1",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-                    "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+                    "version": "1.13.2",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+                    "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
                 },
                 "forever-agent": {
                     "version": "0.6.1",
@@ -608,6 +607,11 @@
                         "mkdirp": ">=0.5 0",
                         "rimraf": "2"
                     }
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
                 },
                 "gauge": {
                     "version": "1.2.7",
@@ -698,14 +702,14 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.2.4",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+                    "version": "4.2.6",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
                 },
                 "handlebars": {
-                    "version": "4.7.6",
-                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-                    "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+                    "version": "4.7.7",
+                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+                    "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
                     "requires": {
                         "minimist": "^1.2.5",
                         "neo-async": "^2.6.0",
@@ -728,6 +732,14 @@
                         "har-schema": "^2.0.0"
                     }
                 },
+                "has": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
                 "has-unicode": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -745,9 +757,9 @@
                     }
                 },
                 "highlight.js": {
-                    "version": "10.0.3",
-                    "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
-                    "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ=="
+                    "version": "10.6.0",
+                    "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+                    "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
                 },
                 "http-signature": {
                     "version": "1.2.0",
@@ -784,9 +796,9 @@
                     "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
                 },
                 "interpret": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-                    "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
                 },
                 "invert-kv": {
                     "version": "1.0.0",
@@ -800,6 +812,14 @@
                     "requires": {
                         "is-relative": "^1.0.0",
                         "is-windows": "^1.0.1"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+                    "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+                    "requires": {
+                        "has": "^1.0.3"
                     }
                 },
                 "is-extglob": {
@@ -957,9 +977,9 @@
                     "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
                 },
                 "lunr": {
-                    "version": "2.3.8",
-                    "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-                    "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
+                    "version": "2.3.9",
+                    "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+                    "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
                 },
                 "marked": {
                     "version": "1.0.0",
@@ -975,16 +995,16 @@
                     }
                 },
                 "mime-db": {
-                    "version": "1.45.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-                    "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+                    "version": "1.46.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+                    "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
                 },
                 "mime-types": {
-                    "version": "2.1.28",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-                    "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+                    "version": "2.1.29",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+                    "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
                     "requires": {
-                        "mime-db": "1.45.0"
+                        "mime-db": "1.46.0"
                     }
                 },
                 "minimatch": {
@@ -1071,9 +1091,9 @@
                     }
                 },
                 "mqtt-packet": {
-                    "version": "6.7.0",
-                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.7.0.tgz",
-                    "integrity": "sha512-GzgeeCirQpB59FyhHvf8BLiIYgxctPSxuSyaF2vWnkt7paX7jtuQ8Gpl+DkHCxZmYuv7GQE6zcUAegpafd0MqQ==",
+                    "version": "6.8.1",
+                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.8.1.tgz",
+                    "integrity": "sha512-XM+QN6/pNVvoTSAiaOCuOSy8AVau6/8LVdLyMhvv2wJqzJjp8IL/h4R+wTcfm+CV+HhL6i826pHqDTCCKyBdyA==",
                     "requires": {
                         "bl": "^4.0.2",
                         "debug": "^4.1.1",
@@ -1086,9 +1106,9 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "neo-async": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-                    "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+                    "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
                 },
                 "npmlog": {
                     "version": "1.2.1",
@@ -1306,10 +1326,11 @@
                     }
                 },
                 "resolve": {
-                    "version": "1.17.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+                    "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
                     "requires": {
+                        "is-core-module": "^2.2.0",
                         "path-parse": "^1.0.6"
                     }
                 },
@@ -1546,9 +1567,9 @@
                     "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                 },
                 "typedoc": {
-                    "version": "0.17.7",
-                    "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
-                    "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
+                    "version": "0.17.8",
+                    "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+                    "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
                     "requires": {
                         "fs-extra": "^8.1.0",
                         "handlebars": "^4.7.6",
@@ -1559,7 +1580,7 @@
                         "minimatch": "^3.0.0",
                         "progress": "^2.0.3",
                         "shelljs": "^0.8.4",
-                        "typedoc-default-themes": "^0.10.1"
+                        "typedoc-default-themes": "^0.10.2"
                     },
                     "dependencies": {
                         "fs-extra": {
@@ -1575,26 +1596,23 @@
                     }
                 },
                 "typedoc-default-themes": {
-                    "version": "0.10.1",
-                    "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz",
-                    "integrity": "sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==",
+                    "version": "0.10.2",
+                    "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+                    "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
                     "requires": {
                         "lunr": "^2.3.8"
                     }
                 },
                 "typescript": {
-                    "version": "3.9.3",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-                    "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ=="
+                    "version": "3.9.9",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+                    "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
                 },
                 "uglify-js": {
-                    "version": "3.9.3",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
-                    "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
-                    "optional": true,
-                    "requires": {
-                        "commander": "~2.20.3"
-                    }
+                    "version": "3.12.8",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+                    "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+                    "optional": true
                 },
                 "ultron": {
                     "version": "1.1.1",
@@ -1663,9 +1681,9 @@
                     }
                 },
                 "uri-js": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-                    "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+                    "version": "4.4.1",
+                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+                    "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -1780,9 +1798,9 @@
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "ws": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-                    "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+                    "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
                 },
                 "xtend": {
                     "version": "4.0.2",
@@ -1813,6 +1831,21 @@
                         "y18n": "^3.2.0"
                     }
                 }
+            }
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "cliui": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+            "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
             }
         },
         "color-convert": {
@@ -1851,6 +1884,11 @@
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
         "locate-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -1861,9 +1899,9 @@
             }
         },
         "p-limit": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-            "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -1901,16 +1939,49 @@
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
+        "string-width": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+            "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+            "requires": {
+                "ansi-regex": "^4.1.0"
+            }
+        },
         "typescript": {
-            "version": "3.9.7",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
             "dev": true
         },
         "which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "wrap-ansi": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+            }
+        },
+        "y18n": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
         },
         "yargs": {
             "version": "14.2.3",
@@ -1928,61 +1999,6 @@
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
                 "yargs-parser": "^15.0.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-                },
-                "cliui": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-                    "requires": {
-                        "string-width": "^3.1.0",
-                        "strip-ansi": "^5.2.0",
-                        "wrap-ansi": "^5.1.0"
-                    }
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-                    "requires": {
-                        "ansi-styles": "^3.2.0",
-                        "string-width": "^3.0.0",
-                        "strip-ansi": "^5.0.0"
-                    }
-                },
-                "y18n": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-                }
             }
         },
         "yargs-parser": {
@@ -1992,13 +2008,6 @@
             "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-                }
             }
         }
     }

--- a/samples/node/pub_sub/index.ts
+++ b/samples/node/pub_sub/index.ts
@@ -108,9 +108,9 @@ async function execute_session(connection: mqtt.MqttClientConnection, argv: Args
     return new Promise(async (resolve, reject) => {
         try {
             const decoder = new TextDecoder('utf8');
-            const on_publish = async (topic: string, payload: ArrayBuffer) => {
+            const on_publish = async (topic: string, payload: ArrayBuffer, dup: boolean, qos: mqtt.QoS, retain: boolean) => {
                 const json = decoder.decode(payload);
-                console.log(`Publish received on topic ${topic}`);
+                console.log(`Publish received. topic:"${topic}" dup:${dup} qos:${qos} retain:${retain}`);
                 console.log(json);
                 const message = JSON.parse(json);
                 if (message.sequence == argv.count) {

--- a/samples/node/pub_sub/package-lock.json
+++ b/samples/node/pub_sub/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@types/node": {
-            "version": "10.17.50",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
-            "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
+            "version": "10.17.54",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+            "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==",
             "dev": true
         },
         "ansi-regex": {
@@ -26,7 +26,7 @@
         "aws-iot-device-sdk-v2": {
             "version": "file:../../..",
             "requires": {
-                "aws-crt": "1.3.7"
+                "aws-crt": "1.5.1"
             },
             "dependencies": {
                 "@convergencelabs/typedoc-plugin-custom-modules": {
@@ -35,9 +35,9 @@
                     "integrity": "sha512-SbQ+YqdMh5nRKBDNWvVx9Hvq8xaZEDJoG98qwuWS/udrm3bK1yAwmwqt5vWwtiaDYZoUXEWro1EbxcCDU7V56w=="
                 },
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-                    "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+                    "version": "10.17.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+                    "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ=="
                 },
                 "ajv": {
                     "version": "6.12.6",
@@ -122,15 +122,15 @@
                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 },
                 "aws-crt": {
-                    "version": "1.3.7",
-                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.3.7.tgz",
-                    "integrity": "sha512-20MgLc1DoYma5y2ogcCB3ee+no130JCZ8/vY6b5qCvfbcJjgX6tdhJVOWAXPtz1EafLoJLwWRC5/VVywVQgIhQ==",
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.5.1.tgz",
+                    "integrity": "sha512-SkipCfrN50TCGE8RKEemsDCIJMHtP56ryWumSW1pDVRHO4/++nVdWu0UTD0JNIb6DOFmXv5yj7tFRixHMChz3Q==",
                     "requires": {
                         "axios": "^0.21.1",
                         "cmake-js": "^6.1.0",
                         "crypto-js": "^3.3.0",
                         "fastestsmallesttextencoderdecoder": "^1.0.22",
-                        "mqtt": "^4.2.1",
+                        "mqtt": "^4.2.6",
                         "websocket-stream": "^5.5.2"
                     }
                 },
@@ -185,9 +185,9 @@
                     }
                 },
                 "bl": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-                    "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+                    "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
                     "requires": {
                         "buffer": "^5.5.0",
                         "inherits": "^2.0.4",
@@ -338,12 +338,6 @@
                     "requires": {
                         "delayed-stream": "~1.0.0"
                     }
-                },
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "optional": true
                 },
                 "commist": {
                     "version": "1.1.0",
@@ -561,9 +555,9 @@
                     "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
                 },
                 "follow-redirects": {
-                    "version": "1.13.1",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-                    "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+                    "version": "1.13.2",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+                    "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
                 },
                 "forever-agent": {
                     "version": "0.6.1",
@@ -613,6 +607,11 @@
                         "mkdirp": ">=0.5 0",
                         "rimraf": "2"
                     }
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
                 },
                 "gauge": {
                     "version": "1.2.7",
@@ -703,14 +702,14 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.2.4",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+                    "version": "4.2.6",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
                 },
                 "handlebars": {
-                    "version": "4.7.6",
-                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-                    "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+                    "version": "4.7.7",
+                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+                    "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
                     "requires": {
                         "minimist": "^1.2.5",
                         "neo-async": "^2.6.0",
@@ -733,6 +732,14 @@
                         "har-schema": "^2.0.0"
                     }
                 },
+                "has": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
                 "has-unicode": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -750,9 +757,9 @@
                     }
                 },
                 "highlight.js": {
-                    "version": "10.0.3",
-                    "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
-                    "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ=="
+                    "version": "10.6.0",
+                    "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+                    "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
                 },
                 "http-signature": {
                     "version": "1.2.0",
@@ -789,9 +796,9 @@
                     "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
                 },
                 "interpret": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-                    "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
                 },
                 "invert-kv": {
                     "version": "1.0.0",
@@ -805,6 +812,14 @@
                     "requires": {
                         "is-relative": "^1.0.0",
                         "is-windows": "^1.0.1"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+                    "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+                    "requires": {
+                        "has": "^1.0.3"
                     }
                 },
                 "is-extglob": {
@@ -962,9 +977,9 @@
                     "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
                 },
                 "lunr": {
-                    "version": "2.3.8",
-                    "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-                    "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
+                    "version": "2.3.9",
+                    "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+                    "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
                 },
                 "marked": {
                     "version": "1.0.0",
@@ -980,16 +995,16 @@
                     }
                 },
                 "mime-db": {
-                    "version": "1.45.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-                    "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+                    "version": "1.46.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+                    "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
                 },
                 "mime-types": {
-                    "version": "2.1.28",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-                    "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+                    "version": "2.1.29",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+                    "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
                     "requires": {
-                        "mime-db": "1.45.0"
+                        "mime-db": "1.46.0"
                     }
                 },
                 "minimatch": {
@@ -1076,9 +1091,9 @@
                     }
                 },
                 "mqtt-packet": {
-                    "version": "6.7.0",
-                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.7.0.tgz",
-                    "integrity": "sha512-GzgeeCirQpB59FyhHvf8BLiIYgxctPSxuSyaF2vWnkt7paX7jtuQ8Gpl+DkHCxZmYuv7GQE6zcUAegpafd0MqQ==",
+                    "version": "6.8.1",
+                    "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.8.1.tgz",
+                    "integrity": "sha512-XM+QN6/pNVvoTSAiaOCuOSy8AVau6/8LVdLyMhvv2wJqzJjp8IL/h4R+wTcfm+CV+HhL6i826pHqDTCCKyBdyA==",
                     "requires": {
                         "bl": "^4.0.2",
                         "debug": "^4.1.1",
@@ -1091,9 +1106,9 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "neo-async": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-                    "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+                    "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
                 },
                 "npmlog": {
                     "version": "1.2.1",
@@ -1311,10 +1326,11 @@
                     }
                 },
                 "resolve": {
-                    "version": "1.17.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+                    "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
                     "requires": {
+                        "is-core-module": "^2.2.0",
                         "path-parse": "^1.0.6"
                     }
                 },
@@ -1551,9 +1567,9 @@
                     "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                 },
                 "typedoc": {
-                    "version": "0.17.7",
-                    "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
-                    "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
+                    "version": "0.17.8",
+                    "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+                    "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
                     "requires": {
                         "fs-extra": "^8.1.0",
                         "handlebars": "^4.7.6",
@@ -1564,7 +1580,7 @@
                         "minimatch": "^3.0.0",
                         "progress": "^2.0.3",
                         "shelljs": "^0.8.4",
-                        "typedoc-default-themes": "^0.10.1"
+                        "typedoc-default-themes": "^0.10.2"
                     },
                     "dependencies": {
                         "fs-extra": {
@@ -1580,26 +1596,23 @@
                     }
                 },
                 "typedoc-default-themes": {
-                    "version": "0.10.1",
-                    "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz",
-                    "integrity": "sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==",
+                    "version": "0.10.2",
+                    "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+                    "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
                     "requires": {
                         "lunr": "^2.3.8"
                     }
                 },
                 "typescript": {
-                    "version": "3.9.3",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-                    "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ=="
+                    "version": "3.9.9",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+                    "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
                 },
                 "uglify-js": {
-                    "version": "3.9.3",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
-                    "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
-                    "optional": true,
-                    "requires": {
-                        "commander": "~2.20.3"
-                    }
+                    "version": "3.12.8",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+                    "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+                    "optional": true
                 },
                 "ultron": {
                     "version": "1.1.1",
@@ -1668,9 +1681,9 @@
                     }
                 },
                 "uri-js": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-                    "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+                    "version": "4.4.1",
+                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+                    "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -1785,9 +1798,9 @@
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "ws": {
-                    "version": "7.4.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-                    "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+                    "version": "7.4.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+                    "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
                 },
                 "xtend": {
                     "version": "4.0.2",
@@ -1945,9 +1958,9 @@
             }
         },
         "typescript": {
-            "version": "3.9.7",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
             "dev": true
         },
         "which-module": {


### PR DESCRIPTION
Update brings:
- **IMPROVEMENT**: The MQTT `on_message` event, and the topic-specific callback passed to `subscribe()`, have added `dup`, `qos`, and `retain` params.
- **IMPROVEMENT**: Outgoing MQTT `Payload` type now accepts `ArrayBuffer` and any `ArrayBufferView` (ex: `Uint8Array`) type.
- **BUGFIX**: `on_message` payload typescript signature changed from `Buffer` to `ArrayBuffer`.
  - This is a semi-breaking change. There were two callback passing payloads, one signature claimed to pass `ArrayBuffer` payloads and the other claimed to pass `Buffer` payloads. In reality the node implementation always passed `ArrayBuffer` and the browser implementation always passed `Buffer`. Now, both callbacks share a signature, they both claim to pass `ArrayBuffer` and both the node and browser implementations **actually do** pass `ArrayBuffer`
- **BUGFIX**: browser MQTT `publish()` no longer tries to turn everything to strings. `ArrayBuffer` and `ArrayBufferView` types will pass their bytes straight through.
- **BUGFIX**: browser MQTT `unsubscribe()`



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
