### PR TITLE
Update README.md to add yum commands for required libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ to JS by the [awscrt](https://github.com/awslabs/aws-crt-nodejs) package.
 node -v
 ```
 
-### Install the required libraries
+### Install the required libraries using apt
 ```
 sudo apt-get install cmake
 sudo apt-get install libssl-dev
+```
+
+### Install the required libraries using yum
+```
+sudo yum install cmake
+sudo yum install openssl-devel
 ```
 
 ### Install the AWS Common Runtime


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update README.md to add yum commands for required libs. The name of libssl-dev pkg is different when installing using yum on Amazon Linux2 and by extension centos etc...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
