### PR TITLE
Add Greengrass V2 documentation links to Greengrass discovery sample README

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -271,5 +271,8 @@ node dist/index.js \
 
 ## Greengrass Discovery (Basic Discovery)
 
-This sample intended for use directly with the
-[Getting Started with AWS IoT Greengrass](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html) guide.
+This sample is intended for use with the following tutorials in the AWS IoT Greengrass documentation:
+
+* [Connect and test client devices](https://docs.aws.amazon.com/greengrass/v2/developerguide/client-devices-tutorial.html) (Greengrass V2)
+* [Test client device communications](https://docs.aws.amazon.com/greengrass/v2/developerguide/test-client-device-communications.html) (Greengrass V2)
+* [Getting Started with AWS IoT Greengrass](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html) (Greengrass V1)


### PR DESCRIPTION
Update the Greengrass discovery sample README to add links to Greengrass V2 documentation, because Greengrass V2 now supports client devices and Greengrass discovery. Previously, the README included only a link to Greengrass V1 documentation.

*Issue #, if available:*

*Description of changes:*
Add links to Greengrass V2 documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
