### PR TITLE
Minor command line wording adjustments to better fit other SDKs

### DIFF
--- a/samples/node/basic_discovery/index.ts
+++ b/samples/node/basic_discovery/index.ts
@@ -12,65 +12,65 @@ const yargs = require('yargs');
 yargs.command('*', false, (yargs: any) => {
     yargs.option('ca_file', {
             alias: 'r',
-            description: 'FILE: path to a Root CA certificate file in PEM format.',
+            description: '<path>: path to a Root CA certificate file in PEM format. (optional, system trust store used by default)',
             type: 'string',
             required: true
         })
         .option('cert', {
             alias: 'c',
-            description: 'FILE: path to a PEM encoded certificate to use with mTLS',
+            description: '<path>: path to a PEM encoded certificate to use with mTLS',
             type: 'string',
             required: true
         })
         .option('key', {
             alias: 'k',
-            description: 'FILE: Path to a PEM encoded private key that matches cert.',
+            description: '<path>: Path to a PEM encoded private key that matches cert.',
             type: 'string',
             required: true
         })
         .option('thing_name', {
             alias: 'n',
-            description: 'STRING: Targeted Thing name.',
+            description: 'Targeted Thing name.',
             type: 'string',
             required: true
         })
         .option('topic', {
             alias: 't',
-            description: 'STRING: Targeted topic',
+            description: 'Targeted topic. (optional)',
             type: 'string',
             default: 'test/topic'
         })
         .option('mode', {
             alias: 'm',
-            description: 'STRING: [publish, subscribe, both]. Defaults to both',
+            description: 'Mode options: [publish, subscribe, both]. (optional)',
             type: 'string',
             default: 'both',
             choices: ['publish', 'subscribe', 'both']
         })
         .option('message', {
             alias: 'M',
-            description: 'STRING: Message to publish.',
+            description: 'Message to publish (optional).',
             type: 'string',
             default: 'Hello world!'
         })
         .option('region', {
-            description: 'STRING: AWS Region.',
+            description: 'AWS Region (optional).',
             type: 'string',
             default: 'us-east-1'
         })
-        .option('max_pub_ops', {
-            description: 'NUMBER: Maximum number of publishes to send',
+        .option('count', {
+            description: 'Maximum number of publishes to send (optional).',
             type: 'number',
             default: 10
         })
         .option('print_discover_resp_only', {
-            description: 'BOOLEAN: Only print the response from Greengrass discovery',
+            description: 'Only print the response from Greengrass discovery (optional)',
             type: 'boolean',
             default: false
         })
         .option('verbose', {
             alias: 'v',
-            description: 'BOOLEAN: Verbose output',
+            description: 'Verbose output (optional)',
             type: 'string',
             default: 'none',
             choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'none']
@@ -152,7 +152,7 @@ async function execute_session(connection: mqtt.MqttClientConnection, argv: Args
                     console.log(`Publish received. topic:"${topic}" dup:${dup} qos:${qos} retain:${retain}`);
                     console.log(json);
                     const message = JSON.parse(json);
-                    if (message.sequence == argv.max_pub_ops) {
+                    if (message.sequence == argv.count) {
                         resolve();
                     }
                 }
@@ -160,7 +160,7 @@ async function execute_session(connection: mqtt.MqttClientConnection, argv: Args
             }
 
             if (argv.mode == 'both' || argv.mode == 'publish') {
-                for (let op_idx = 0; op_idx < argv.max_pub_ops; ++op_idx) {
+                for (let op_idx = 0; op_idx < argv.count; ++op_idx) {
                     const publish = async () => {
                         const msg = {
                             message: argv.message,

--- a/samples/node/basic_discovery/index.ts
+++ b/samples/node/basic_discovery/index.ts
@@ -12,13 +12,13 @@ const yargs = require('yargs');
 yargs.command('*', false, (yargs: any) => {
     yargs.option('ca_file', {
             alias: 'r',
-            description: '<path>: path to a Root CA certificate file in PEM format. (optional, system trust store used by default)',
+            description: '<path>: path to a Root CA certificate file in PEM format (optional, system trust store used by default).',
             type: 'string',
             required: true
         })
         .option('cert', {
             alias: 'c',
-            description: '<path>: path to a PEM encoded certificate to use with mTLS',
+            description: '<path>: path to a PEM encoded certificate to use with mTLS.',
             type: 'string',
             required: true
         })
@@ -36,13 +36,13 @@ yargs.command('*', false, (yargs: any) => {
         })
         .option('topic', {
             alias: 't',
-            description: 'Targeted topic. (optional)',
+            description: 'Targeted topic (optional).',
             type: 'string',
             default: 'test/topic'
         })
         .option('mode', {
             alias: 'm',
-            description: 'Mode options: [publish, subscribe, both]. (optional)',
+            description: 'Mode options: [publish, subscribe, both] (optional).',
             type: 'string',
             default: 'both',
             choices: ['publish', 'subscribe', 'both']
@@ -64,13 +64,13 @@ yargs.command('*', false, (yargs: any) => {
             default: 10
         })
         .option('print_discover_resp_only', {
-            description: 'Only print the response from Greengrass discovery (optional)',
+            description: 'Only print the response from Greengrass discovery (optional).',
             type: 'boolean',
             default: false
         })
         .option('verbose', {
             alias: 'v',
-            description: 'Verbose output (optional)',
+            description: 'Verbose output (optional).',
             type: 'string',
             default: 'none',
             choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'none']

--- a/samples/node/fleet_provisioning/index.ts
+++ b/samples/node/fleet_provisioning/index.ts
@@ -18,19 +18,19 @@ yargs.command('*', false, (yargs: any) => {
     yargs
         .option('csr_file', {
             alias: 'csr',
-            description: 'FILE: Path to a CSR file in PEM format',
+            description: '<path>: Path to a CSR file in PEM format',
             type: 'string',
             required: false
         })
         .option('template_name', {
               alias: 't',
-              description: 'STRING: Template Name',
+              description: 'Template Name',
               type: 'string',
               required: true
          })
          .option('template_parameters', {
               alias: 'tp',
-              description: 'Template parameters json ',
+              description: '<json>: Template parameters json ',
               type: 'string',
               required: false
          })

--- a/samples/node/fleet_provisioning/index.ts
+++ b/samples/node/fleet_provisioning/index.ts
@@ -18,19 +18,19 @@ yargs.command('*', false, (yargs: any) => {
     yargs
         .option('csr_file', {
             alias: 'csr',
-            description: '<path>: Path to a CSR file in PEM format',
+            description: '<path>: Path to a CSR file in PEM format.',
             type: 'string',
             required: false
         })
         .option('template_name', {
               alias: 't',
-              description: 'Template Name',
+              description: 'Template Name.',
               type: 'string',
               required: true
          })
          .option('template_parameters', {
               alias: 'tp',
-              description: '<json>: Template parameters json ',
+              description: '<json>: Template parameters json.',
               type: 'string',
               required: false
          })

--- a/samples/node/pub_sub_pkcs11/index.ts
+++ b/samples/node/pub_sub_pkcs11/index.ts
@@ -35,7 +35,7 @@ yargs.command('*', false, (yargs: any) => {
             required: true,
         })
         .option('pkcs11_lib', {
-            description: "<path> Path to PKCS#11 library.",
+            description: "<path>: Path to PKCS#11 library.",
             type: 'string',
             required: true,
         })

--- a/samples/node/pub_sub_pkcs11/index.ts
+++ b/samples/node/pub_sub_pkcs11/index.ts
@@ -30,12 +30,12 @@ yargs.command('*', false, (yargs: any) => {
             required: true,
         })
         .option('cert', {
-            description: "Path to your certificate file in PEM format.",
+            description: "<path>: Path to your certificate file in PEM format.",
             type: 'string',
             required: true,
         })
         .option('pkcs11_lib', {
-            description: "Path to PKCS#11 library.",
+            description: "<path> Path to PKCS#11 library.",
             type: 'string',
             required: true,
         })
@@ -57,7 +57,7 @@ yargs.command('*', false, (yargs: any) => {
             type: 'string',
         })
         .option('ca_file', {
-            description: "Path to a Root CA certificate file in PEM format.",
+            description: "<path>: Path to a Root CA certificate file in PEM format (optional, system trust store used by default).",
             type: 'string',
         })
         .option('client_id', {
@@ -65,23 +65,23 @@ yargs.command('*', false, (yargs: any) => {
             type: 'string',
         })
         .option('topic', {
-            description: "Topic to publish to",
+            description: "Topic to publish to (optional)",
             type: 'string',
             default: 'test/topic'
         })
         .option('count', {
             default: 10,
             description: "Number of messages to publish/receive before exiting. " +
-                "Specify 0 to run forever.",
+                "Specify 0 to run forever (optional).",
             type: 'number',
         })
         .option('message', {
-            description: "Message to publish.",
+            description: "Message to publish (optional).",
             type: 'string',
             default: 'Hello world!'
         })
         .option('verbosity', {
-            description: "The amount of detail in the logging output of the sample.",
+            description: "The amount of detail in the logging output of the sample (optional).",
             type: 'string',
             choices: ['error', 'warn', 'info', 'debug', 'trace', 'none']
         })

--- a/samples/util/cli_args.js
+++ b/samples/util/cli_args.js
@@ -36,13 +36,13 @@ function add_connection_establishment_arguments(yargs) {
         })
         .option('ca_file', {
             alias: 'r',
-            description: '<path>: File path to a Root CA certificate file in PEM format. (optional, system trust store used by default)',
+            description: '<path>: File path to a Root CA certificate file in PEM format (optional, system trust store used by default).',
             type: 'string',
             required: false
         })
         .option('cert', {
             alias: 'c',
-            description: '<path>: File path to a PEM encoded certificate to use with mTLS',
+            description: '<path>: File path to a PEM encoded certificate to use with mTLS.',
             type: 'string',
             required: false
         })
@@ -62,29 +62,29 @@ function add_connection_establishment_arguments(yargs) {
             alias: 'W',
             default: false,
             description: 'To use a websocket instead of raw mqtt. If you specify this option you must set a region ' +
-                'for signing (signing_region) that matches your endpoint.',
+                'for signing (region) that matches your endpoint.',
             type: 'boolean',
             required: false
         })
-        .option('signing_region', {
+        .option('region', {
             alias: 's',
             default: 'us-east-1',
             description: 'If you specify --use_websocket, this ' +
                 'is the region that will be used for computing the Sigv4 signature.  This region must match the' +
-                'AWS region in your endpoint (optional, default="us-east-1").',
+                'AWS region in your endpoint (optional).',
             type: 'string',
             required: false
         })
         .option('proxy_host', {
             alias: 'H',
-            description: 'Hostname of the proxy to connect to',
+            description: 'Hostname of the proxy to connect to (optional, required if --proxy_port is set).',
             type: 'string',
             required: false
         })
         .option('proxy_port', {
             alias: 'P',
             default: 8080,
-            description: 'Port of the proxy to connect to (optional).',
+            description: 'Port of the proxy to connect to (optional, required if --proxy_host is set).',
             type: 'number',
             required: false
         })
@@ -107,21 +107,21 @@ function add_pub_sub_arguments(yargs) {
     yargs
         .option('topic', {
             alias: 't',
-            description: '<str>: Topic to publish to (optional, default="test/topic")',
+            description: 'Topic to publish to (optional).',
             type: 'string',
             default: 'test/topic'
         })
         .option('count', {
             alias: 'n',
             default: 10,
-            description: '<int>: Number of messages to publish/receive before exiting. ' +
-                'Specify 0 to run forever. (optional, default="10")',
+            description: 'Number of messages to publish/receive before exiting. ' +
+                'Specify 0 to run forever (optional).',
             type: 'number',
             required: false
         })
         .option('message', {
             alias: 'M',
-            description: '<str>: Message to publish (optional, default="Hello world!").',
+            description: 'Message to publish (optional).',
             type: 'string',
             default: 'Hello world!'
         })
@@ -154,7 +154,7 @@ function apply_sample_arguments(argv) {
  */
 function build_websocket_mqtt_connection_from_args(argv) {
     let config_builder = iot.AwsIotMqttConnectionConfigBuilder.new_with_websockets({
-        region: argv.signing_region,
+        region: argv.region,
         credentials_provider: auth.AwsCredentialsProvider.newDefault()
     });
 

--- a/samples/util/cli_args.js
+++ b/samples/util/cli_args.js
@@ -30,26 +30,25 @@ function add_connection_establishment_arguments(yargs) {
     yargs
         .option('endpoint', {
             alias: 'e',
-            description: "Your AWS IoT custom endpoint, not including a port. "  +
-                "Ex: \"abcd123456wxyz-ats.iot.us-east-1.amazonaws.com\"",
+            description: '<path>: Your AWS IoT custom endpoint, not including a port.',
             type: 'string',
             required: true
         })
         .option('ca_file', {
             alias: 'r',
-            description: 'File path to a Root CA certificate file in PEM format.',
+            description: '<path>: File path to a Root CA certificate file in PEM format. (optional, system trust store used by default)',
             type: 'string',
             required: false
         })
         .option('cert', {
             alias: 'c',
-            description: 'File path to a PEM encoded certificate to use with mTLS',
+            description: '<path>: File path to a PEM encoded certificate to use with mTLS',
             type: 'string',
             required: false
         })
         .option('key', {
             alias: 'k',
-            description: 'File path to a PEM encoded private key that matches cert.',
+            description: '<path>: File path to a PEM encoded private key that matches cert.',
             type: 'string',
             required: false
         })
@@ -72,7 +71,7 @@ function add_connection_establishment_arguments(yargs) {
             default: 'us-east-1',
             description: 'If you specify --use_websocket, this ' +
                 'is the region that will be used for computing the Sigv4 signature.  This region must match the' +
-                'AWS region in your endpoint.',
+                'AWS region in your endpoint (optional, default="us-east-1").',
             type: 'string',
             required: false
         })
@@ -85,13 +84,13 @@ function add_connection_establishment_arguments(yargs) {
         .option('proxy_port', {
             alias: 'P',
             default: 8080,
-            description: 'Port of the proxy to connect to.',
+            description: 'Port of the proxy to connect to (optional).',
             type: 'number',
             required: false
         })
         .option('verbosity', {
             alias: 'v',
-            description: 'The amount of detail in the logging output of the sample.',
+            description: 'The amount of detail in the logging output of the sample (optional).',
             type: 'string',
             default: 'none',
             choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'none']
@@ -108,21 +107,21 @@ function add_pub_sub_arguments(yargs) {
     yargs
         .option('topic', {
             alias: 't',
-            description: 'Topic to publish to',
+            description: '<str>: Topic to publish to (optional, default="test/topic")',
             type: 'string',
             default: 'test/topic'
         })
         .option('count', {
             alias: 'n',
             default: 10,
-            description: 'Number of messages to publish/receive before exiting. ' +
-                'Specify 0 to run forever.',
+            description: '<int>: Number of messages to publish/receive before exiting. ' +
+                'Specify 0 to run forever. (optional, default="10")',
             type: 'number',
             required: false
         })
         .option('message', {
             alias: 'M',
-            description: 'Message to publish.',
+            description: '<str>: Message to publish (optional, default="Hello world!").',
             type: 'string',
             default: 'Hello world!'
         })


### PR DESCRIPTION
*Description of changes:*

Adjusts the text in the command line argument descriptions to better fit the wording and format of the other V2 SDKs. These changes are primarily adding optional to the end of optional arguments, as well as mentioning the default key store being used for CA files if none is passed.
This change also changes the argument name from `max_pub_ops` to `count` (in the discovery sample), and `signing_region` to just `region` (in cli_args).

_______

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
