### PR TITLE
Delete Test Resources for Device Advisor

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -15,6 +15,7 @@
         "DA_TOPIC": "test/da",
         "DA_SHADOW_PROPERTY": "datest",
         "DA_SHADOW_VALUE_SET": "ON",
-        "DA_SHADOW_VALUE_DEFAULT": "OFF"
+        "DA_SHADOW_VALUE_DEFAULT": "OFF",
+        "DA_S3_NAME": "aws-iot-sdk-deviceadvisor-logs"
     }
 }

--- a/deviceadvisor/script/DATestRun.py
+++ b/deviceadvisor/script/DATestRun.py
@@ -3,6 +3,7 @@ import uuid
 import json
 import os
 import subprocess
+import re
 from time import sleep
 
 ##############################################
@@ -19,6 +20,20 @@ def delete_thing_with_certi(thingName, certiId, certiArn):
     os.remove(os.environ["DA_CERTI"])
     os.remove(os.environ["DA_KEY"])
 
+# Export the testing log and upload it to S3 bucket
+def process_logs(log_group, log_stream, thing_name):
+    logs_client = boto3.client('logs')
+    response = logs_client.get_log_events(
+        logGroupName=log_group,
+        logStreamName=log_stream
+    )
+    log_file = thing_name + ".log"
+    f = open(log_file, 'w')
+    for event in response["events"]:
+        f.write(event['message'])
+    f.close()
+    s3.Bucket(os.environ['DA_S3_NAME']).upload_file(log_file, log_file)
+    os.remove(log_file)
 
 ##############################################
 # Initialize variables
@@ -26,6 +41,7 @@ def delete_thing_with_certi(thingName, certiId, certiArn):
 client = boto3.client('iot')
 dataClient = boto3.client('iot-data')
 deviceAdvisor = boto3.client('iotdeviceadvisor')
+s3 = boto3.resource('s3')
 
 # load test config
 f = open('deviceadvisor/script/DATestConfig.json')
@@ -199,13 +215,20 @@ for test_name in DATestConfig['tests']:
             # If the test finalizing then store the test result
             elif (test_result_responds['status'] != 'RUNNING'):
                 test_result[test_name] = test_result_responds['status']
-                # Delete the thing if the test passed
-                if(test_result[test_name] == "PASS"):
-                    delete_thing_with_certi(thing_name, certificate_id ,certificate_arn )
+                # If the test failed, upload the logs to S3 before clean up
+                if(test_result[test_name] != "PASS"):
+                    log_url = test_result_responds['testResult']['groups'][0]['tests'][0]['logUrl']
+                    group_string = re.search('group=(.*);', log_url)
+                    log_group = group_string.group(1)
+                    stream_string = re.search('stream=(.*)', log_url)
+                    log_stream = stream_string.group(1)
+                    process_logs(log_group, log_stream, thing_name)
+                delete_thing_with_certi(thing_name, certificate_id ,certificate_arn )
                 break
 
         os.chdir(working_dir)
     except Exception as e:
+        delete_thing_with_certi(thing_name, certificate_id ,certificate_arn )
         print("[Device Advisor]Error: Failed to test: "+ test_name + e)
         exit(-1)
 

--- a/deviceadvisor/script/DATestRun.py
+++ b/deviceadvisor/script/DATestRun.py
@@ -35,8 +35,7 @@ def process_logs(log_group, log_stream, thing_name):
     f.close()
     s3.Bucket(os.environ['DA_S3_NAME']).upload_file(log_file, log_file)
     os.remove(log_file)
-    print("[Device Advisor] Issues on test " + test_name + ". Please check out the logs at "+thing_name+".log on S3.")
-                
+    print("[Device Advisor] Device Advisor Log file uploaded to "+ log_file)
 
 # Sleep for a random time between base and bax
 def sleep_with_backoff(base, max):

--- a/deviceadvisor/tests/mqtt_subscribe/index.ts
+++ b/deviceadvisor/tests/mqtt_subscribe/index.ts
@@ -25,7 +25,7 @@ async function main() {
         await connection.connect();
         
         // subscribe message to topic
-        connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
+        await connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
         
         // disconnect
         await connection.disconnect();

--- a/deviceadvisor/tests/mqtt_subscribe/index.ts
+++ b/deviceadvisor/tests/mqtt_subscribe/index.ts
@@ -6,9 +6,6 @@ import { mqtt } from 'aws-iot-device-sdk-v2';
 import { TestType } from '../utils/datest_utils'
 
 const datest_utils = require('../utils/datest_utils');
-function sleep(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
- }
 
 async function main() {
     if(!datest_utils.validate_vars(TestType.SUB_PUB))
@@ -27,15 +24,17 @@ async function main() {
         await connection.connect();
         
         // subscribe message to topic
+        connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
+        
         /** We dont wait for subscription because we sometime could not recieve suback from device 
          *  advisor. Instead we sleep for 30 seconds to wait for server to processing the subscription
-         *  request.
+         *  request before disconnect.
          */
-        connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
-        sleep(30000);
+        setTimeout(async () => {
+            // disconnect
+            await connection.disconnect();
+        }, 30000);
 
-        // disconnect
-        await connection.disconnect();
     } catch
     {
         process.exit(-1)

--- a/deviceadvisor/tests/mqtt_subscribe/index.ts
+++ b/deviceadvisor/tests/mqtt_subscribe/index.ts
@@ -6,7 +6,9 @@ import { mqtt } from 'aws-iot-device-sdk-v2';
 import { TestType } from '../utils/datest_utils'
 
 const datest_utils = require('../utils/datest_utils');
-
+function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+ }
 
 async function main() {
     if(!datest_utils.validate_vars(TestType.SUB_PUB))
@@ -25,8 +27,13 @@ async function main() {
         await connection.connect();
         
         // subscribe message to topic
-        await connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
-        
+        /** We dont wait for subscription because we sometime could not recieve suback from device 
+         *  advisor. Instead we sleep for 30 seconds to wait for server to processing the subscription
+         *  request.
+         */
+        connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
+        sleep(30);
+
         // disconnect
         await connection.disconnect();
     } catch

--- a/deviceadvisor/tests/mqtt_subscribe/index.ts
+++ b/deviceadvisor/tests/mqtt_subscribe/index.ts
@@ -3,9 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 import { mqtt } from 'aws-iot-device-sdk-v2';
+import { setTimeout } from 'timers';
 import { TestType } from '../utils/datest_utils'
 
 const datest_utils = require('../utils/datest_utils');
+
+const sleep = (milliseconds=500) => new Promise(resolve => setTimeout(resolve, milliseconds))
 
 async function main() {
     if(!datest_utils.validate_vars(TestType.SUB_PUB))
@@ -26,14 +29,14 @@ async function main() {
         // subscribe message to topic
         connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
         
-        /** We dont wait for subscription because we sometime could not recieve suback from device 
-         *  advisor. Instead we sleep for 30 seconds to wait for server to processing the subscription
+        /** We dont use await for subscription because we sometime could not recieve suback from device 
+         *  advisor. Instead we wait for 30 seconds to wait for server to processing the subscription
          *  request before disconnect.
          */
-        setTimeout(async () => {
-            // disconnect
-            await connection.disconnect();
-        }, 30000);
+        await sleep(30000);
+
+        // disconnect
+        await connection.disconnect();
 
     } catch
     {

--- a/deviceadvisor/tests/mqtt_subscribe/index.ts
+++ b/deviceadvisor/tests/mqtt_subscribe/index.ts
@@ -32,7 +32,7 @@ async function main() {
          *  request.
          */
         connection.subscribe(datest_utils.topic, mqtt.QoS.AtMostOnce);
-        sleep(30);
+        sleep(30000);
 
         // disconnect
         await connection.disconnect();


### PR DESCRIPTION
*Description of changes:*
- Update the Device Advisor script. Now it will upload the logs to s3 and then delete the testing resources.
- Added backoff for device advisor requests to improve server traffics

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
