### PR TITLE
Major version upgrades for typescript and typedoc

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -7,7 +7,7 @@
  * Browser entry point for AWS IoT SDK.
  * @packageDocumentation
  * @module aws-iot-device-sdk
- * @preferred
+ * @mergeTarget
  */
 
 import { mqtt, http, io, iot, auth } from 'aws-crt/dist.browser/browser';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,7 +13,7 @@
  *
  * @packageDocumentation
  * @module aws-iot-device-sdk
- * @preferred
+ * @mergeTarget
  */
 
 import * as iotidentity from './iotidentity/iotidentityclient';

--- a/lib/iotidentity/iotidentityclient.ts
+++ b/lib/iotidentity/iotidentityclient.ts
@@ -46,6 +46,16 @@ export class IotIdentityClient {
 
     private decoder = new TextDecoder('utf-8');
 
+    private static INVALID_PAYLOAD_PARSING_ERROR = "Invalid/unknown error parsing payload into response";
+
+    private static createClientError(err: any, payload: ArrayBuffer) : IotIdentityError {
+        if (err instanceof Error) {
+            return new IotIdentityError(err.message, payload);
+        } else {
+            return new IotIdentityError( IotIdentityClient.INVALID_PAYLOAD_PARSING_ERROR, payload);
+        }
+    }
+
     constructor(private connection: mqtt.MqttClientConnection) {
     }
 
@@ -113,7 +123,7 @@ export class IotIdentityClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.CreateKeysAndCertificateResponse;
             } catch (err) {
-                error = new IotIdentityError(err.message, payload);
+                error = IotIdentityClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -160,7 +170,7 @@ export class IotIdentityClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotIdentityError(err.message, payload);
+                error = IotIdentityClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -208,7 +218,7 @@ export class IotIdentityClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotIdentityError(err.message, payload);
+                error = IotIdentityClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -255,7 +265,7 @@ export class IotIdentityClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.CreateCertificateFromCsrResponse;
             } catch (err) {
-                error = new IotIdentityError(err.message, payload);
+                error = IotIdentityClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -331,7 +341,7 @@ export class IotIdentityClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.RegisterThingResponse;
             } catch (err) {
-                error = new IotIdentityError(err.message, payload);
+                error = IotIdentityClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -378,7 +388,7 @@ export class IotIdentityClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotIdentityError(err.message, payload);
+                error = IotIdentityClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);

--- a/lib/iotjobs/iotjobsclient.ts
+++ b/lib/iotjobs/iotjobsclient.ts
@@ -46,6 +46,16 @@ export class IotJobsClient {
 
     private decoder = new TextDecoder('utf-8');
 
+    private static INVALID_PAYLOAD_PARSING_ERROR = "Invalid/unknown error parsing payload into response";
+
+    private static createClientError(err: any, payload: ArrayBuffer) : IotJobsError {
+        if (err instanceof Error) {
+            return new IotJobsError(err.message, payload);
+        } else {
+            return new IotJobsError( IotJobsClient.INVALID_PAYLOAD_PARSING_ERROR, payload);
+        }
+    }
+
     constructor(private connection: mqtt.MqttClientConnection) {
     }
 
@@ -87,7 +97,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.JobExecutionsChangedEvent;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -135,7 +145,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.StartNextJobExecutionResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -184,7 +194,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -232,7 +242,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.NextJobExecutionChangedEvent;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -281,7 +291,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -330,7 +340,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.UpdateJobExecutionResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -408,7 +418,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.DescribeJobExecutionResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -484,7 +494,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.GetPendingJobExecutionsResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -532,7 +542,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -580,7 +590,7 @@ export class IotJobsClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
-                error = new IotJobsError(err.message, payload);
+                error = IotJobsClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);

--- a/lib/iotshadow/iotshadowclient.ts
+++ b/lib/iotshadow/iotshadowclient.ts
@@ -46,6 +46,16 @@ export class IotShadowClient {
 
     private decoder = new TextDecoder('utf-8');
 
+    private static INVALID_PAYLOAD_PARSING_ERROR = "Invalid/unknown error parsing payload into response";
+
+    private static createClientError(err: any, payload: ArrayBuffer) : IotShadowError {
+        if (err instanceof Error) {
+            return new IotShadowError(err.message, payload);
+        } else {
+            return new IotShadowError( IotShadowClient.INVALID_PAYLOAD_PARSING_ERROR, payload);
+        }
+    }
+
     constructor(private connection: mqtt.MqttClientConnection) {
     }
 
@@ -87,7 +97,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -135,7 +145,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ShadowDeltaUpdatedEvent;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -184,7 +194,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -233,7 +243,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -338,7 +348,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.DeleteShadowResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -386,7 +396,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.GetShadowResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -435,7 +445,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.GetShadowResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -484,7 +494,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ShadowUpdatedEvent;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -532,7 +542,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ShadowUpdatedEvent;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -610,7 +620,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.DeleteShadowResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -658,7 +668,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -706,7 +716,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -810,7 +820,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.UpdateShadowResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -859,7 +869,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -937,7 +947,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.ShadowDeltaUpdatedEvent;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);
@@ -986,7 +996,7 @@ export class IotShadowClient {
                 const payload_text = this.decoder.decode(payload);
                 response = JSON.parse(payload_text) as model.UpdateShadowResponse;
             } catch (err) {
-                error = new IotShadowError(err.message, payload);
+                error = IotShadowClient.createClientError(err, payload);
             }
             finally {
                 messageHandler(error, response);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
       "version": "1.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "aws-crt": "1.12.5"
+        "aws-crt": "^1.13.0"
       },
       "devDependencies": {
-        "@types/node": "^10.17.50",
-        "cmake-js": "^6.1.0",
-        "typedoc": "^0.17.8",
-        "typedoc-plugin-external-module-name": "^4.0.6",
-        "typedoc-plugin-remove-references": "^0.0.5",
-        "typescript": "^3.9.7"
+        "@types/node": "^10.17.54",
+        "cmake-js": "^6.3.0",
+        "typedoc": "^0.22.18",
+        "typedoc-plugin-merge-modules": "^3.1.0",
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@httptoolkit/websocket-stream": {
-      "version": "6.0.0",
-      "license": "BSD-2-Clause",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.1.tgz",
+      "integrity": "sha512-A0NOZI+Glp3Xgcz6Na7i7o09+/+xm2m0UCU8gdtM2nIv6/cjLmhMZMqehSpTlgbx9omtLmV8LVqOskPEyWnmZQ==",
       "dependencies": {
         "@types/ws": "*",
         "duplexify": "^3.5.1",
@@ -36,19 +36,15 @@
     },
     "node_modules/@types/node": {
       "version": "10.17.60",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/ws/node_modules/@types/node": {
-      "version": "17.0.35",
-      "license": "MIT"
     },
     "node_modules/ansi": {
       "version": "0.3.1",
@@ -70,9 +66,9 @@
       }
     },
     "node_modules/aws-crt": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.12.5.tgz",
-      "integrity": "sha512-fIMKy7BKHEWC4gzqewYJTlmp+m9ioZuBSfcKf2zYFSIZxtmweHji6n+sicHDcynxNA5zUsFPcVbKhOryfyAKfw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.13.0.tgz",
+      "integrity": "sha512-4TnGrN/cyp9hsGd+a19EgTyL8k/J9KiU9SlEVGgLimKVGEk8ApJynSvcFgmh1qLC+6/EvZ5NcPUBnuBKfWnYMg==",
       "hasInstallScript": true,
       "dependencies": {
         "@httptoolkit/websocket-stream": "^6.0.0",
@@ -87,7 +83,8 @@
     },
     "node_modules/axios": {
       "version": "0.24.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
         "follow-redirects": "^1.14.4"
       }
@@ -98,6 +95,8 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -111,8 +110,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
@@ -131,7 +129,8 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -140,7 +139,8 @@
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -164,6 +164,8 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -178,7 +180,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -186,7 +187,8 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
@@ -291,7 +293,8 @@
     },
     "node_modules/commist": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
       "dependencies": {
         "leven": "^2.1.0",
         "minimist": "^1.1.0"
@@ -303,10 +306,11 @@
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
         "node >= 6.0"
       ],
-      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -316,7 +320,8 @@
     },
     "node_modules/concat-stream/node_modules/readable-stream": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -332,7 +337,8 @@
     },
     "node_modules/crypto-js": {
       "version": "4.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -376,7 +382,8 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -386,14 +393,16 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
       }
     },
     "node_modules/fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
-      "license": "CC0-1.0"
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
@@ -446,11 +455,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gauge": {
       "version": "1.2.7",
       "license": "ISC",
@@ -484,44 +488,14 @@
       "version": "4.2.10",
       "license": "ISC"
     },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "license": "ISC"
     },
     "node_modules/help-me": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
       "dependencies": {
         "glob": "^7.1.6",
         "readable-stream": "^3.6.0"
@@ -529,7 +503,8 @@
     },
     "node_modules/help-me/node_modules/readable-stream": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -539,16 +514,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -562,8 +531,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -581,30 +549,11 @@
       "version": "1.3.8",
       "license": "ISC"
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -631,14 +580,22 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/js-sdsl": {
       "version": "2.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A=="
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -659,7 +616,8 @@
     },
     "node_modules/leven": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -686,7 +644,8 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -696,22 +655,25 @@
     },
     "node_modules/lru-cache/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/lunr": {
       "version": "2.3.9",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
     },
     "node_modules/marked": {
-      "version": "1.0.0",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/memory-stream": {
@@ -782,7 +744,8 @@
     },
     "node_modules/mqtt": {
       "version": "4.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
+      "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
       "dependencies": {
         "commist": "^1.0.0",
         "concat-stream": "^2.0.0",
@@ -813,7 +776,8 @@
     },
     "node_modules/mqtt-packet": {
       "version": "6.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
       "dependencies": {
         "bl": "^4.0.2",
         "debug": "^4.1.1",
@@ -822,7 +786,8 @@
     },
     "node_modules/mqtt/node_modules/duplexify": {
       "version": "4.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -832,7 +797,8 @@
     },
     "node_modules/mqtt/node_modules/readable-stream": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -846,11 +812,6 @@
       "version": "2.1.2",
       "license": "MIT"
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npmlog": {
       "version": "1.2.1",
       "license": "ISC",
@@ -862,7 +823,8 @@
     },
     "node_modules/number-allocator": {
       "version": "1.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
+      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
       "dependencies": {
         "debug": "^4.3.1",
         "js-sdsl": "^2.1.2"
@@ -899,26 +861,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -954,39 +904,15 @@
       "version": "5.1.2",
       "license": "MIT"
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/reinterval": {
       "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/resolve": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.8.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ=="
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
@@ -1027,42 +953,29 @@
       "version": "1.0.5",
       "license": "MIT"
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/split2": {
       "version": "3.2.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "dependencies": {
         "readable-stream": "^3.0.0"
       }
     },
     "node_modules/split2/node_modules/readable-stream": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1078,7 +991,8 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1120,20 +1034,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/tar": {
       "version": "6.1.11",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -1148,14 +1052,16 @@
     },
     "node_modules/tar/node_modules/chownr": {
       "version": "2.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -1164,8 +1070,9 @@
       }
     },
     "node_modules/tar/node_modules/minipass": {
-      "version": "3.1.6",
-      "license": "ISC",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1175,7 +1082,8 @@
     },
     "node_modules/tar/node_modules/minizlib": {
       "version": "2.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -1186,7 +1094,8 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -1196,7 +1105,8 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/traverse": {
       "version": "0.3.9",
@@ -1204,111 +1114,91 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typedoc": {
-      "version": "0.17.8",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.0.0",
-        "lodash": "^4.17.15",
-        "lunr": "^2.3.8",
-        "marked": "1.0.0",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.10.2"
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": ">=3.8.3"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
       }
     },
-    "node_modules/typedoc-default-themes": {
-      "version": "0.10.2",
+    "node_modules/typedoc-plugin-merge-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-3.1.0.tgz",
+      "integrity": "sha512-DAHDZD+KG3mRm+hJFAMh/pO98CQ3W/BFA81FzWpc1kos66mLRIa7QVO30yBREkZNZMsTA7fgGEjEN2GO2cgi3A==",
       "dev": true,
-      "license": "Apache-2.0",
+      "peerDependencies": {
+        "typedoc": "0.21.x || 0.22.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
-        "lunr": "^2.3.8"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typedoc-plugin-external-module-name": {
-      "version": "4.0.6",
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "lodash": "^4.1.2",
-        "semver": "^7.1.1"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.7.0 <0.20.0"
-      }
-    },
-    "node_modules/typedoc-plugin-external-module-name/node_modules/semver": {
-      "version": "7.3.7",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/typedoc-plugin-remove-references": {
-      "version": "0.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/typedoc/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/typescript": {
-      "version": "3.9.10",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.15.5",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/universalify": {
@@ -1362,6 +1252,18 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "license": "ISC",
@@ -1382,11 +1284,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/wrap-ansi": {
       "version": "2.1.0",
       "license": "MIT",
@@ -1404,7 +1301,8 @@
     },
     "node_modules/ws": {
       "version": "7.5.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -1423,7 +1321,8 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
       }
@@ -1452,7 +1351,9 @@
   },
   "dependencies": {
     "@httptoolkit/websocket-stream": {
-      "version": "6.0.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.1.tgz",
+      "integrity": "sha512-A0NOZI+Glp3Xgcz6Na7i7o09+/+xm2m0UCU8gdtM2nIv6/cjLmhMZMqehSpTlgbx9omtLmV8LVqOskPEyWnmZQ==",
       "requires": {
         "@types/ws": "*",
         "duplexify": "^3.5.1",
@@ -1465,18 +1366,14 @@
       }
     },
     "@types/node": {
-      "version": "10.17.60",
-      "dev": true
+      "version": "10.17.60"
     },
     "@types/ws": {
       "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "requires": {
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "17.0.35"
-        }
       }
     },
     "ansi": {
@@ -1493,9 +1390,9 @@
       }
     },
     "aws-crt": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.12.5.tgz",
-      "integrity": "sha512-fIMKy7BKHEWC4gzqewYJTlmp+m9ioZuBSfcKf2zYFSIZxtmweHji6n+sicHDcynxNA5zUsFPcVbKhOryfyAKfw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.13.0.tgz",
+      "integrity": "sha512-4TnGrN/cyp9hsGd+a19EgTyL8k/J9KiU9SlEVGgLimKVGEk8ApJynSvcFgmh1qLC+6/EvZ5NcPUBnuBKfWnYMg==",
       "requires": {
         "@httptoolkit/websocket-stream": "^6.0.0",
         "axios": "^0.24.0",
@@ -1509,6 +1406,8 @@
     },
     "axios": {
       "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
         "follow-redirects": "^1.14.4"
       }
@@ -1517,7 +1416,9 @@
       "version": "1.0.2"
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "big-integer": {
       "version": "1.6.51"
@@ -1531,6 +1432,8 @@
     },
     "bl": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1539,6 +1442,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -1559,13 +1464,17 @@
     },
     "buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buffer-indexof-polyfill": {
       "version": "1.0.2"
@@ -1641,6 +1550,8 @@
     },
     "commist": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
       "requires": {
         "leven": "^2.1.0",
         "minimist": "^1.1.0"
@@ -1651,6 +1562,8 @@
     },
     "concat-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -1660,6 +1573,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -1672,7 +1587,9 @@
       "version": "1.0.3"
     },
     "crypto-js": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -1697,6 +1614,8 @@
     },
     "duplexify": {
       "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -1706,12 +1625,16 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
     },
     "fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22"
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "follow-redirects": {
       "version": "1.15.1"
@@ -1742,10 +1665,6 @@
         "rimraf": "2"
       }
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "dev": true
-    },
     "gauge": {
       "version": "1.2.7",
       "requires": {
@@ -1770,29 +1689,13 @@
     "graceful-fs": {
       "version": "4.2.10"
     },
-    "handlebars": {
-      "version": "4.7.7",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-unicode": {
       "version": "2.0.1"
     },
     "help-me": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
       "requires": {
         "glob": "^7.1.6",
         "readable-stream": "^3.6.0"
@@ -1800,6 +1703,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -1808,12 +1713,10 @@
         }
       }
     },
-    "highlight.js": {
-      "version": "10.7.3",
-      "dev": true
-    },
     "ieee754": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1828,19 +1731,8 @@
     "ini": {
       "version": "1.3.8"
     },
-    "interpret": {
-      "version": "1.4.0",
-      "dev": true
-    },
     "invert-kv": {
       "version": "1.0.0"
-    },
-    "is-core-module": {
-      "version": "2.9.0",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -1859,10 +1751,20 @@
     },
     "isomorphic-ws": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "requires": {}
     },
     "js-sdsl": {
-      "version": "2.1.4"
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A=="
+    },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -1877,7 +1779,9 @@
       }
     },
     "leven": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA=="
     },
     "listenercount": {
       "version": "1.0.1"
@@ -1896,21 +1800,29 @@
     },
     "lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
       },
       "dependencies": {
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
     "lunr": {
       "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
     "marked": {
-      "version": "1.0.0",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
       "dev": true
     },
     "memory-stream": {
@@ -1968,6 +1880,8 @@
     },
     "mqtt": {
       "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
+      "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
       "requires": {
         "commist": "^1.0.0",
         "concat-stream": "^2.0.0",
@@ -1990,6 +1904,8 @@
       "dependencies": {
         "duplexify": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
           "requires": {
             "end-of-stream": "^1.4.1",
             "inherits": "^2.0.3",
@@ -1999,6 +1915,8 @@
         },
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2009,6 +1927,8 @@
     },
     "mqtt-packet": {
       "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
       "requires": {
         "bl": "^4.0.2",
         "debug": "^4.1.1",
@@ -2017,10 +1937,6 @@
     },
     "ms": {
       "version": "2.1.2"
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "dev": true
     },
     "npmlog": {
       "version": "1.2.1",
@@ -2032,6 +1948,8 @@
     },
     "number-allocator": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
+      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
       "requires": {
         "debug": "^4.3.1",
         "js-sdsl": "^2.1.2"
@@ -2055,19 +1973,13 @@
     "path-is-absolute": {
       "version": "1.0.1"
     },
-    "path-parse": {
-      "version": "1.0.7",
-      "dev": true
-    },
     "process-nextick-args": {
       "version": "2.0.1"
     },
-    "progress": {
-      "version": "2.0.3",
-      "dev": true
-    },
     "pump": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2099,27 +2011,15 @@
         }
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "reinterval": {
-      "version": "1.1.0"
-    },
-    "resolve": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.8.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ=="
     },
     "rfdc": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "rimraf": {
       "version": "2.7.1",
@@ -2136,29 +2036,29 @@
     "setimmediate": {
       "version": "1.0.5"
     },
-    "shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+    "shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
       }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "dev": true
     },
     "split2": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
         "readable-stream": "^3.0.0"
       },
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2171,7 +2071,9 @@
       "version": "0.0.7"
     },
     "stream-shift": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -2201,12 +2103,10 @@
     "strip-json-comments": {
       "version": "2.0.1"
     },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "tar": {
       "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -2217,32 +2117,44 @@
       },
       "dependencies": {
         "chownr": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
         },
         "fs-minipass": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "requires": {
             "minipass": "^3.0.0"
           }
         },
         "minipass": {
-          "version": "3.1.6",
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+          "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "minizlib": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
           }
         },
         "mkdirp": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -2250,71 +2162,68 @@
       "version": "0.3.9"
     },
     "typedarray": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typedoc": {
-      "version": "0.17.8",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
       "requires": {
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.0.0",
-        "lodash": "^4.17.15",
-        "lunr": "^2.3.8",
-        "marked": "1.0.0",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.10.2"
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         }
       }
     },
-    "typedoc-default-themes": {
-      "version": "0.10.2",
+    "typedoc-plugin-merge-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-3.1.0.tgz",
+      "integrity": "sha512-DAHDZD+KG3mRm+hJFAMh/pO98CQ3W/BFA81FzWpc1kos66mLRIa7QVO30yBREkZNZMsTA7fgGEjEN2GO2cgi3A==",
       "dev": true,
-      "requires": {
-        "lunr": "^2.3.8"
-      }
-    },
-    "typedoc-plugin-external-module-name": {
-      "version": "4.0.6",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.1.2",
-        "semver": "^7.1.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "typedoc-plugin-remove-references": {
-      "version": "0.0.5",
-      "dev": true
+      "requires": {}
     },
     "typescript": {
-      "version": "3.9.10",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.15.5",
-      "dev": true,
-      "optional": true
     },
     "universalify": {
       "version": "0.1.2"
@@ -2359,6 +2268,18 @@
     "util-deprecate": {
       "version": "1.0.2"
     },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
+    },
     "which": {
       "version": "1.3.1",
       "requires": {
@@ -2367,10 +2288,6 @@
     },
     "window-size": {
       "version": "0.1.4"
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -2384,10 +2301,14 @@
     },
     "ws": {
       "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
       "requires": {}
     },
     "xtend": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.2"

--- a/package.json
+++ b/package.json
@@ -24,19 +24,13 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@types/node": "^10.17.50",
-    "cmake-js": "^6.1.0",
-    "typedoc": "^0.17.8",
-    "typedoc-plugin-external-module-name": "^4.0.6",
-    "typedoc-plugin-remove-references": "^0.0.5",
-    "typescript": "^3.9.7"
+    "@types/node": "^10.17.54",
+    "cmake-js": "^6.3.0",
+    "typedoc": "^0.22.18",
+    "typedoc-plugin-merge-modules": "^3.1.0",
+    "typescript": "^4.7.4"
   },
   "dependencies": {
-    "aws-crt": "1.12.5"
-  },
-  "resolutions": {
-    "minimist": "1.2.6",
-    "shelljs": "0.8.5",
-    "tar@4.4.17": "4.4.19"
+    "aws-crt": "^1.13.0"
   }
 }

--- a/samples/browser/custom_authorizer_connect/index.js
+++ b/samples/browser/custom_authorizer_connect/index.js
@@ -7,7 +7,7 @@ const iotsdk = require("aws-iot-device-sdk-v2");
 const iot = iotsdk.iot;
 const mqtt = iotsdk.mqtt;
 const AWS = require("aws-sdk");
-const Settings = require("./Settings");
+const Settings = require("./settings");
 const $ = require("jquery");
 
 function log(msg) {

--- a/samples/browser/custom_authorizer_connect/package.json
+++ b/samples/browser/custom_authorizer_connect/package.json
@@ -25,18 +25,13 @@
     },
     "main": "./index.js",
     "devDependencies": {
-        "@babel/core": "^7.17.5",
-        "@babel/preset-env": "^7.16.11",
         "@types/jquery": "^3.3.31",
-        "@webpack-cli/generators": "^2.4.2",
-        "babel-loader": "^8.2.3",
         "node-polyfill-webpack-plugin": "^1.1.4",
-        "prettier": "^2.4.1",
-        "source-map-loader": "^0.2.4",
-        "ts-loader": "^6.2.1",
-        "typescript": "^3.7.3",
-        "webpack": "^5.72.1",
-        "webpack-cli": "^4.9.2"
+        "source-map-loader": "^4.0.0",
+        "ts-loader": "^9.3.1",
+        "typescript": "^4.7.4",
+        "webpack": "^5.73.0",
+        "webpack-cli": "^4.10.0"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/browser/pub_sub/index.ts
+++ b/samples/browser/pub_sub/index.ts
@@ -5,7 +5,7 @@
 
 import { mqtt, iot, auth } from "aws-iot-device-sdk-v2";
 import * as AWS from "aws-sdk";
-const Settings = require("./Settings");
+const Settings = require("./settings");
 const $ = require("jquery");
 
 function log(msg: string) {

--- a/samples/browser/pub_sub/package.json
+++ b/samples/browser/pub_sub/package.json
@@ -25,18 +25,13 @@
   },
   "main": "./index.js",
   "devDependencies": {
-    "@babel/core": "^7.17.5",
-    "@babel/preset-env": "^7.16.11",
     "@types/jquery": "^3.3.31",
-    "@webpack-cli/generators": "^2.4.2",
-    "babel-loader": "^8.2.3",
     "node-polyfill-webpack-plugin": "^1.1.4",
-    "prettier": "^2.4.1",
-    "source-map-loader": "^0.2.4",
-    "ts-loader": "^6.2.1",
-    "typescript": "^3.7.3",
-    "webpack": "^5.69.1",
-    "webpack-cli": "^4.9.2"
+    "source-map-loader": "^4.0.0",
+    "ts-loader": "^9.3.1",
+    "typescript": "^4.7.4",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
     "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/basic_connect/package.json
+++ b/samples/node/basic_connect/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/basic_discovery/index.ts
+++ b/samples/node/basic_discovery/index.ts
@@ -123,7 +123,7 @@ async function connect_to_iot(mqtt_client: mqtt.MqttClient, argv: Args, discover
 }
 
 async function execute_session(connection: mqtt.MqttClientConnection, argv: Args) {
-    return new Promise(async (resolve, reject) => {
+    return new Promise<void>(async (resolve, reject) => {
         try {
             const decoder = new TextDecoder('utf8');
             if (argv.mode == 'both' || argv.mode == 'subscribe') {

--- a/samples/node/basic_discovery/package.json
+++ b/samples/node/basic_discovery/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.7.3"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/custom_authorizer_connect/package.json
+++ b/samples/node/custom_authorizer_connect/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/fleet_provisioning/index.ts
+++ b/samples/node/fleet_provisioning/index.ts
@@ -94,7 +94,7 @@ async function execute_keys(identity: iotidentity.IotIdentityClient, argv: Args)
 }
 
 async function execute_register_thing(identity: iotidentity.IotIdentityClient, token: string, argv: Args) {
-    return new Promise(async (resolve, reject) => {
+    return new Promise<void>(async (resolve, reject) => {
         try {
             function registerAccepted(error?: iotidentity.IotIdentityError, response?: iotidentity.model.RegisterThingResponse) {
                 if (response) {
@@ -181,7 +181,9 @@ async function execute_csr(identity: iotidentity.IotIdentityClient, argv: Args) 
             try {
                 csr = fs.readFileSync(argv.csr_file, 'utf8');
             } catch (e) {
-                console.log('Error reading CSR PEM file:', e.stack);
+                if (e instanceof Error) {
+                    console.log('Error reading CSR PEM file:', e.stack);
+                }
             }
             console.log("Subscribing to CreateCertificateFromCsr Accepted and Rejected topics..");
 

--- a/samples/node/fleet_provisioning/package.json
+++ b/samples/node/fleet_provisioning/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/pkcs11_connect/package.json
+++ b/samples/node/pkcs11_connect/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/pub_sub/package.json
+++ b/samples/node/pub_sub/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/shadow/package.json
+++ b/samples/node/shadow/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "../../../",

--- a/samples/node/websocket_connect/package.json
+++ b/samples/node/websocket_connect/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/samples/node/windows_cert_connect/package.json
+++ b/samples/node/windows_cert_connect/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "file:../../..",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,15 +1,32 @@
 {
-    "mode": "modules",
-    "inputFiles": ["lib/index.ts"],
+    "entryPoints": [
+        "lib/index.ts",
+        "build/docs/aws-crt-nodejs/lib/native/auth.ts",
+        "build/docs/aws-crt-nodejs/lib/native/aws_iot.ts",
+        "build/docs/aws-crt-nodejs/lib/native/checksums.ts",
+        "build/docs/aws-crt-nodejs/lib/native/crt.ts",
+        "build/docs/aws-crt-nodejs/lib/native/crypto.ts",
+        "build/docs/aws-crt-nodejs/lib/native/error.ts",
+        "build/docs/aws-crt-nodejs/lib/native/http.ts",
+        "build/docs/aws-crt-nodejs/lib/native/io.ts",
+        "build/docs/aws-crt-nodejs/lib/native/mqtt.ts",
+        "build/docs/aws-crt-nodejs/lib/native/binding.d.ts",
+        "build/docs/aws-crt-nodejs/lib/common/auth.ts",
+        "build/docs/aws-crt-nodejs/lib/common/crypto.ts",
+        "build/docs/aws-crt-nodejs/lib/common/event.ts",
+        "build/docs/aws-crt-nodejs/lib/common/http.ts",
+        "build/docs/aws-crt-nodejs/lib/common/mqtt.ts",
+        "build/docs/aws-crt-nodejs/lib/common/resource_safety.ts"
+    ],
     "out": "docs",
     "tsconfig": "tsconfig-docs.json",
-    "includeDeclarations": true,
     "excludeExternals": true,
-    "excludeNotExported": true,
     "excludePrivate": true,
-    "stripInternal": true,
+    "excludeInternal": true,
+    "excludeProtected": true,
     "disableSources": true,
     "categorizeByGroup": true,
-    "listInvalidSymbolLinks": true
+    "treatWarningsAsErrors" : false,
+    "mergeModulesMergeMode": "module"
 }
 


### PR DESCRIPTION
* Update typescript to latest
* Update typedoc to almost-latest MV
* Update typedoc config to account for all the breaking changes
* Swap typedoc plugins to modern ones that still work and do approximately what we had plugins doing before.
* Re-export service clients to address pickier type-checking in 4.x
* Update sample package.jsons and fix some misc. type-check errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
