### PR TITLE
Adjust browser pubsub to show cognito use

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -107,7 +107,8 @@ node index.js --endpoint <endpoint> --ca_file <file> --cert <file> --key <file>
 This is a browser based version of the PubSub sample in JS.
 
 To run the sample:
-1) Configure your credentials and endpoint URL in `settings.js`, you can chose to use cognito or static credentials.
+1) Configure your credentials and endpoint URL in `settings.js`.
+    * You will need to setup a Cognito identity pool to run this sample. You can read how to setup a Cognito identity pool here: [AWS documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/tutorial-create-identity-pool.html).
 
 2) Build the script via `npm install`
 

--- a/samples/browser/pub_sub/settings.js
+++ b/samples/browser/pub_sub/settings.js
@@ -1,6 +1,3 @@
 export const AWS_REGION = "<your region>";
 export const AWS_IOT_ENDPOINT = "<your endpoint>";
 export const AWS_COGNITO_IDENTITY_POOL_ID = "<your cognito identity pool id>";
-export const AWS_STATIC_ACCESS_KEY = "<your static access key>";
-export const AWS_STATIC_SECRET_ACCESS_KEY = "<your static secret access key>";
-export const AWS_STATIC_ACCESS_TOKEN = "Optional: <your static access token>";

--- a/samples/browser/pub_sub/settings.js
+++ b/samples/browser/pub_sub/settings.js
@@ -1,6 +1,6 @@
 export const AWS_REGION = "<your region>";
 export const AWS_IOT_ENDPOINT = "<your endpoint>";
-export const AWS_COGNITO_IDENTITY_POOL_ID = "Optional: <your identity pool id>";
+export const AWS_COGNITO_IDENTITY_POOL_ID = "<your cognito identity pool id>";
 export const AWS_STATIC_ACCESS_KEY = "<your static access key>";
 export const AWS_STATIC_SECRET_ACCESS_KEY = "<your static secret access key>";
 export const AWS_STATIC_ACCESS_TOKEN = "Optional: <your static access token>";


### PR DESCRIPTION
*Description of changes:*

Modifies the browser pub-sub sample ReadMe and settings to show that Cognito credentials are required to run the sample, as well as to link to the AWS documentation for making a Cognito identity pool.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
