### PR TITLE
Remove typo in the shadow sample cmd in README

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -485,7 +485,7 @@ To run the Shadow sample use the following command:
 
 ``` sh
 npm install
-node dist/index.js --endpoint <endpoint> --ca_file <path to root CA1> --cert <path to the certificate> --key <path to the private key> -- thing_name <thing name> --shadow_property <shadow property name>
+node dist/index.js --endpoint <endpoint> --ca_file <path to root CA1> --cert <path to the certificate> --key <path to the private key> --thing_name <thing name> --shadow_property <shadow property name>
 ```
 
 This will allow you to run the program and set the shadow property by typing in the console.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed the mistaken space between '--' and 'thing_name' param in the sample Shadow cmd line in the README

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
