### PR TITLE
Browser Service Clients

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -10,6 +10,11 @@
  * @mergeTarget
  */
 
+import * as iotidentity from './iotidentity/iotidentityclient';
+import * as greengrass from './greengrass/discoveryclient';
+import * as iotjobs from './iotjobs/iotjobsclient';
+import * as iotshadow from './iotshadow/iotshadowclient';
+
 import {
     auth,
     http,
@@ -21,9 +26,13 @@ import {
 
 export {
     auth,
+    greengrass,
     http,
     io,
     iot,
+    iotidentity,
+    iotjobs,
+    iotshadow,
     mqtt,
     mqtt5
 }

--- a/lib/greengrass/discoveryclient.ts
+++ b/lib/greengrass/discoveryclient.ts
@@ -10,7 +10,7 @@
  */
 
 import { io, http, CrtError } from 'aws-crt';
-import { TextDecoder } from 'util';
+import { toUtf8 } from '@aws-sdk/util-utf8-browser';
 import * as model from './model';
 export { model };
 
@@ -82,14 +82,13 @@ export class DiscoveryClient {
                         new http.HttpHeaders([['host', this.endpoint]]));
                     const stream = connection.request(request);
                     let response = '';
-                    const decoder = new TextDecoder('utf8');
                     stream.on('response', (status_code, headers) => {
                         if (status_code != 200) {
                             reject(new DiscoveryError(`Discovery failed (headers: ${headers})`, status_code));
                         }
                     });
                     stream.on('data', (body_data) => {
-                        response += decoder.decode(body_data);
+                        response += toUtf8(new Uint8Array(body_data));
                     });
                     stream.on('end', () => {
                         const json = JSON.parse(response);

--- a/lib/iotidentity/iotidentityclient.ts
+++ b/lib/iotidentity/iotidentityclient.ts
@@ -12,7 +12,7 @@
 
 import * as model from "./model";
 import { mqtt, mqtt5 } from "aws-crt";
-import { TextDecoder } from "util";
+import { toUtf8 } from "@aws-sdk/util-utf8-browser"
 import * as service_client_mqtt_adapter from "../service_client_mqtt_adapter";
 
 export { model };
@@ -48,8 +48,6 @@ export class IotIdentityClient {
 
     // @ts-ignore
     private mqttAdapter: service_client_mqtt_adapter.IServiceClientMqttAdapter;
-
-    private decoder = new TextDecoder('utf-8');
 
     private static INVALID_PAYLOAD_PARSING_ERROR = "Invalid/unknown error parsing payload into response";
 
@@ -151,7 +149,7 @@ export class IotIdentityClient {
             let response: model.CreateKeysAndCertificateResponse | undefined;
             let error: IotIdentityError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.CreateKeysAndCertificateResponse;
             } catch (err) {
                 error = IotIdentityClient.createClientError(err, payload);
@@ -198,7 +196,7 @@ export class IotIdentityClient {
             let response: model.ErrorResponse | undefined;
             let error: IotIdentityError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotIdentityClient.createClientError(err, payload);
@@ -246,7 +244,7 @@ export class IotIdentityClient {
             let response: model.ErrorResponse | undefined;
             let error: IotIdentityError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotIdentityClient.createClientError(err, payload);
@@ -293,7 +291,7 @@ export class IotIdentityClient {
             let response: model.CreateCertificateFromCsrResponse | undefined;
             let error: IotIdentityError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.CreateCertificateFromCsrResponse;
             } catch (err) {
                 error = IotIdentityClient.createClientError(err, payload);
@@ -369,7 +367,7 @@ export class IotIdentityClient {
             let response: model.RegisterThingResponse | undefined;
             let error: IotIdentityError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.RegisterThingResponse;
             } catch (err) {
                 error = IotIdentityClient.createClientError(err, payload);
@@ -416,7 +414,7 @@ export class IotIdentityClient {
             let response: model.ErrorResponse | undefined;
             let error: IotIdentityError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotIdentityClient.createClientError(err, payload);

--- a/lib/iotjobs/iotjobsclient.ts
+++ b/lib/iotjobs/iotjobsclient.ts
@@ -12,7 +12,7 @@
 
 import * as model from "./model";
 import { mqtt, mqtt5 } from "aws-crt";
-import { TextDecoder } from "util";
+import { toUtf8 } from "@aws-sdk/util-utf8-browser"
 import * as service_client_mqtt_adapter from "../service_client_mqtt_adapter";
 
 export { model };
@@ -48,8 +48,6 @@ export class IotJobsClient {
 
     // @ts-ignore
     private mqttAdapter: service_client_mqtt_adapter.IServiceClientMqttAdapter;
-
-    private decoder = new TextDecoder('utf-8');
 
     private static INVALID_PAYLOAD_PARSING_ERROR = "Invalid/unknown error parsing payload into response";
 
@@ -125,7 +123,7 @@ export class IotJobsClient {
             let response: model.JobExecutionsChangedEvent | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.JobExecutionsChangedEvent;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -173,7 +171,7 @@ export class IotJobsClient {
             let response: model.StartNextJobExecutionResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.StartNextJobExecutionResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -222,7 +220,7 @@ export class IotJobsClient {
             let response: model.RejectedErrorResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -270,7 +268,7 @@ export class IotJobsClient {
             let response: model.NextJobExecutionChangedEvent | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.NextJobExecutionChangedEvent;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -319,7 +317,7 @@ export class IotJobsClient {
             let response: model.RejectedErrorResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -368,7 +366,7 @@ export class IotJobsClient {
             let response: model.UpdateJobExecutionResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.UpdateJobExecutionResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -446,7 +444,7 @@ export class IotJobsClient {
             let response: model.DescribeJobExecutionResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.DescribeJobExecutionResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -522,7 +520,7 @@ export class IotJobsClient {
             let response: model.GetPendingJobExecutionsResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.GetPendingJobExecutionsResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -570,7 +568,7 @@ export class IotJobsClient {
             let response: model.RejectedErrorResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);
@@ -618,7 +616,7 @@ export class IotJobsClient {
             let response: model.RejectedErrorResponse | undefined;
             let error: IotJobsError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.RejectedErrorResponse;
             } catch (err) {
                 error = IotJobsClient.createClientError(err, payload);

--- a/lib/iotshadow/iotshadowclient.ts
+++ b/lib/iotshadow/iotshadowclient.ts
@@ -12,7 +12,7 @@
 
 import * as model from "./model";
 import { mqtt, mqtt5 } from "aws-crt";
-import { TextDecoder } from "util";
+import { toUtf8 } from "@aws-sdk/util-utf8-browser"
 import * as service_client_mqtt_adapter from "../service_client_mqtt_adapter";
 
 export { model };
@@ -48,8 +48,6 @@ export class IotShadowClient {
 
     // @ts-ignore
     private mqttAdapter: service_client_mqtt_adapter.IServiceClientMqttAdapter;
-
-    private decoder = new TextDecoder('utf-8');
 
     private static INVALID_PAYLOAD_PARSING_ERROR = "Invalid/unknown error parsing payload into response";
 
@@ -125,7 +123,7 @@ export class IotShadowClient {
             let response: model.ErrorResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -173,7 +171,7 @@ export class IotShadowClient {
             let response: model.ShadowDeltaUpdatedEvent | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ShadowDeltaUpdatedEvent;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -222,7 +220,7 @@ export class IotShadowClient {
             let response: model.ErrorResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -271,7 +269,7 @@ export class IotShadowClient {
             let response: model.ErrorResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -376,7 +374,7 @@ export class IotShadowClient {
             let response: model.DeleteShadowResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.DeleteShadowResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -424,7 +422,7 @@ export class IotShadowClient {
             let response: model.GetShadowResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.GetShadowResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -473,7 +471,7 @@ export class IotShadowClient {
             let response: model.GetShadowResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.GetShadowResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -522,7 +520,7 @@ export class IotShadowClient {
             let response: model.ShadowUpdatedEvent | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ShadowUpdatedEvent;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -570,7 +568,7 @@ export class IotShadowClient {
             let response: model.ShadowUpdatedEvent | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ShadowUpdatedEvent;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -648,7 +646,7 @@ export class IotShadowClient {
             let response: model.DeleteShadowResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.DeleteShadowResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -696,7 +694,7 @@ export class IotShadowClient {
             let response: model.ErrorResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -744,7 +742,7 @@ export class IotShadowClient {
             let response: model.ErrorResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -848,7 +846,7 @@ export class IotShadowClient {
             let response: model.UpdateShadowResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.UpdateShadowResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -897,7 +895,7 @@ export class IotShadowClient {
             let response: model.ErrorResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ErrorResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -975,7 +973,7 @@ export class IotShadowClient {
             let response: model.ShadowDeltaUpdatedEvent | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.ShadowDeltaUpdatedEvent;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);
@@ -1024,7 +1022,7 @@ export class IotShadowClient {
             let response: model.UpdateShadowResponse | undefined;
             let error: IotShadowError | undefined;
             try {
-                const payload_text = this.decoder.decode(payload);
+                const payload_text = toUtf8(new Uint8Array(payload));
                 response = JSON.parse(payload_text) as model.UpdateShadowResponse;
             } catch (err) {
                 error = IotShadowClient.createClientError(err, payload);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@aws-sdk/util-utf8-browser": "^3.109.0",
     "aws-crt": "^1.15.5"
   }
 }


### PR DESCRIPTION
* Export service and greengrass discovery clients in the browser
* Replace problematic TextDecoder usage with the polymorphic polyfill provided by the aws-sdk module for text conversion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
