### PR TITLE
Fix minor mistake in release YAML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 env:
-  GH_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ github.token }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 env:
-  GITHUB_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ secrets.TAG_PR_TOKEN }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write # allow push
       pull-requests: write # allow making PR
+      id-token: write # This is required for requesting the JWT
 
     steps:
     - name: Checkout Sources

--- a/utils/publish-release.sh
+++ b/utils/publish-release.sh
@@ -52,7 +52,7 @@ git add ../README.md
 git commit -m "[v$new_version] $RELEASE_TITLE"
 
 # # push the commit and create a PR
-git push -u "https://${GITHUB_ACTOR}:${GH_TOKEN}@github.com/aws/aws-iot-device-sdk-js-v2.git" ${new_version_branch}
+git push -u "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/aws/aws-iot-device-sdk-js-v2.git" ${new_version_branch}
 gh pr create --title "AutoTag PR for v${new_version}" --body "AutoTag PR for v${new_version}" --head ${new_version_branch}
 
 # # Merge the PR


### PR DESCRIPTION
*Description of changes:*

Fixes a super minor mistake in the release YAML. In my testing repository I had the environment variable as `GH_TOKEN` but in this repository (and the others) I renamed it to `GITHUB_TOKEN` but forgot to change it in the YAML 🤦

______________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
