### PR TITLE
Only make lightweight tags in CD

### DIFF
--- a/utils/publish-release.sh
+++ b/utils/publish-release.sh
@@ -64,8 +64,8 @@ git fetch
 git checkout main
 git pull "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/aws/aws-iot-device-sdk-js-v2.git" main
 
-# Create new tag on latest commit with the release title
-git tag -f v${new_version} -m "${RELEASE_TITLE}"
+# Create new tag on latest commit (lightweight tag - we do NOT want an annotated tag)
+git tag -f v${new_version}
 # Push new tag to github
 git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/aws/aws-iot-device-sdk-js-v2.git" --tags
 


### PR DESCRIPTION
*Description of changes:*

Our CD currently makes annotated tags due to passing a tag title when we make the tag in CD. This has the unfortunate side effect of making TWO tags each time we make a release because of how the annotated tag system works: One that is a lightweight tag that just points to the commit, and then another tag that points to both the lightweight tag AND the commit. This leads to having tags with `<tag>^{}` in it. Tested and removing passing a message makes the CD pipeline only send a lightweight tag, fixing the issue.

Created to fix https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/519

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
