### PR TITLE
Update aws-crt-nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,9 +60,9 @@
       }
     },
     "aws-crt": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.6.tgz",
-      "integrity": "sha512-J8MBgxHnMUxHnPL/C1sSlbecQaNE44jAh3MeNQiKQsXf2lFIb3ydccRUPzIpeXHwZ2T5YaFbXDIHdeGpgVeStg==",
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.8.tgz",
+      "integrity": "sha512-2TLgxvcHwYaCpaZWwMTn7628Xa7mcpedE+pdGf+Vg2l6MiTrRKZ5X5YyXMqX4GvfvDB1I3EfIAi5iFxlHZ1J4w==",
       "requires": {
         "@aws-sdk/util-utf8-browser": "^3.109.0",
         "@httptoolkit/websocket-stream": "^6.0.0",
@@ -500,9 +500,9 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "js-sdsl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
-      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ=="
     },
     "jsonc-parser": {
       "version": "3.0.0",
@@ -730,12 +730,12 @@
       }
     },
     "number-allocator": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.12.tgz",
-      "integrity": "sha512-sGB0qoQGmKimery9JubBQ9pQUr1V/LixJAk3Ygp7obZf6mpSXime8d7XHEobbIimkdZpgjkNlLt6G7LPEWFYWg==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
       "requires": {
         "debug": "^4.3.1",
-        "js-sdsl": "4.1.4"
+        "js-sdsl": "4.3.0"
       }
     },
     "number-is-nan": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "@aws-sdk/util-utf8-browser": "^3.109.0",
-    "aws-crt": "^1.15.6"
+    "aws-crt": "^1.15.8"
   }
 }


### PR DESCRIPTION
*Description of changes:*

Updates to get latest changes in `aws-crt-nodejs` - mainly fixes overall. Adds MQTT311 operation statistics support.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
