### PR TITLE
Add Cognito connect sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   DA_SHADOW_VALUE_DEFAULT: OFF
   CI_IOT_CONTAINERS: ${{ secrets.AWS_CI_IOT_CONTAINERS }}
   CI_PUBSUB_ROLE: ${{ secrets.AWS_CI_PUBSUB_ROLE }}
+  CI_COGNITO_ROLE: ${{ secrets.AWS_CI_COGNITO_ROLE }}
   CI_CUSTOM_AUTHORIZER_ROLE: ${{ secrets.AWS_CI_CUSTOM_AUTHORIZER_ROLE }}
   CI_SHADOW_ROLE: ${{ secrets.AWS_CI_SHADOW_ROLE }}
   CI_JOBS_ROLE: ${{ secrets.AWS_CI_JOBS_ROLE }}
@@ -203,6 +204,14 @@ jobs:
         export SOFTHSM2_CONF=/tmp/softhsm2.conf
         echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
         python3 ./aws-iot-device-sdk-js-v2/utils/run_sample_ci.py --file ./aws-iot-device-sdk-js-v2/.github/workflows/ci_run_pkcs11_connect_cfg.json
+    - name: configure AWS credentials (Cognito)
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ env.CI_COGNITO_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: run Cognito Connect sample
+      run: |
+        python3 ./aws-iot-device-sdk-js-v2/utils/run_sample_ci.py --file ./aws-iot-device-sdk-js-v2/.github/workflows/ci_run_cognito_connect_cfg.json
     - name: configure AWS credentials (Custom Authorizer)
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/ci_run_cognito_connect_cfg.json
+++ b/.github/workflows/ci_run_cognito_connect_cfg.json
@@ -1,0 +1,20 @@
+{
+    "language": "Javascript",
+    "sample_file": "./aws-iot-device-sdk-js-v2/samples/node/cognito_connect",
+    "sample_region": "us-east-1",
+    "sample_main_class": "",
+    "arguments": [
+        {
+            "name": "--endpoint",
+            "secret": "ci/endpoint"
+        },
+        {
+            "name": "--signing_region",
+            "data": "us-east-1"
+        },
+        {
+            "name": "--cognito_identity",
+            "secret": "ci/Cognito/identity_id"
+        }
+    ]
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,6 +9,8 @@
 * [Windows Cert Connect](#node-windows-cert-connect)
 * [Custom Authorizer Connect](#node-custom-authorizer-connect)
 * [Browser: Custom Authorizer Connect](#browser-custom-authorizer-connect)
+* [Cognito Connect](#node-cognito-connect)
+* [Browser: Cognito Connect](#browser-cognito-connect)
 * [Shadow](#node-shadow)
 * [Fleet Provisioning](#fleet-provisioning)
 * [Jobs](#jobs)
@@ -408,6 +410,58 @@ To run the sample:
 * Configure your credentials and endpoint in the `browser/custom_authorizer_connect/settings.js` file. Any setting marked as `Optional` can be left without modifications and it will not be used.
 * Run `npm install` in the `browser/custom_authorizer_connect` folder
 * Open `browser/custom_authorizer_connect/index.html` from your browser
+
+## Node: Cognito Connect
+
+This sample makes an MQTT websocket connection and connects through a [Cognito](https://aws.amazon.com/cognito/) identity. On startup, the device connects to the server and then disconnects. This sample is for reference on connecting using Cognito.
+
+To run this sample, you need to have a Cognito identifier ID. You can get a Cognito identifier ID by creating a Cognito identity pool. For creating Cognito identity pools, please see the following page on the AWS documentation: [Tutorial: Creating an identity pool](https://docs.aws.amazon.com/cognito/latest/developerguide/tutorial-create-identity-pool.html)
+
+**Note:** This sample assumes using an identity pool with unauthenticated identity access for the sake of convenience. Please follow best practices in a real world application based on the needs of your application and the intended use case.
+
+Once you have a Cognito identity pool, you can run the following CLI command to get the Cognito identity pool ID:
+
+```sh
+aws cognito-identity get-id --identity-pool-id <cognito identity pool id>
+# result from above command
+{
+    "IdentityId": "<cognito identity ID>"
+}
+```
+
+You can then use the returned ID in the `IdentityId` result as the input for the `--cognito_identity` argument. Please note that the Cognito identity pool ID is **not** the same as a Cognito identity ID and the sample will not work if you pass a Cognito pool id.
+
+Your IoT Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
+
+<details>
+<summary>(see sample policy)</summary>
+<pre>
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Connect"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+      ]
+    }
+  ]
+}
+</pre>
+</details>
+
+Run the sample like this:
+``` sh
+npm install
+node dist/index.js --endpoint <endpoint> --signing_region <signing region> --cognito_identity <cognito identity ID>
+```
+
+## Browser: Cognito Connect
+
+See the Browser Pub/Sub sample for an example of how to connect to AWS via Cognito on the browser: [Browser Pub/Sub sample](#browser-pubsub)
 
 ## Node: Shadow
 

--- a/samples/node/cognito_connect/index.ts
+++ b/samples/node/cognito_connect/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import { mqtt, iot, http, auth} from 'aws-iot-device-sdk-v2';
+type Args = { [index: string]: any };
+
+const yargs = require('yargs');
+
+
+// The relative path is '../../util/cli_args' from here, but the compiled javascript file gets put one level
+// deeper inside the 'dist' folder
+const common_args = require('../../../util/cli_args');
+
+yargs.command('*', false, (yargs: any) => {
+    yargs.usage("Connect using a Cognito identity.");
+    common_args.add_universal_arguments(yargs);
+    common_args.add_common_mqtt_arguments(yargs);
+    common_args.add_common_websocket_arguments(yargs, true);
+    common_args.add_cognito_arguments(yargs);
+    common_args.add_proxy_arguments(yargs);
+}, main).parse();
+
+// Creates and returns a websocket MQTT connection using Cognito to authenticate
+function build_connection(argv: Args): mqtt.MqttClientConnection {
+    /**
+     * Note: This sample assumes that you are using a Cognito identity in the same region as you pass to "--signing_region".
+     * If not, you may need to adjust the Cognito endpoint. See https://docs.aws.amazon.com/general/latest/gr/cognito_identity.html
+     * for all Cognito region endpoints.
+     */
+    let cognito_endpoint = "cognito-identity." + argv.signing_region + ".amazonaws.com";
+
+    let cognito_credentials : iot.WebsocketConfig = {
+        region: argv.signing_region,
+        credentials_provider: auth.AwsCredentialsProvider.newCognito({
+            endpoint: cognito_endpoint,
+            identity: argv.cognito_identity
+        })
+    }
+    let config_builder = iot.AwsIotMqttConnectionConfigBuilder.new_websocket_builder(cognito_credentials);
+
+    if (argv.proxy_host) {
+        config_builder.with_http_proxy_options(new http.HttpProxyOptions(argv.proxy_host, argv.proxy_port));
+    }
+    if (argv.ca_file != null) {
+        config_builder.with_certificate_authority_from_path(undefined, argv.ca_file);
+    }
+
+    config_builder.with_clean_session(false);
+    config_builder.with_client_id(argv.client_id || "test-" + Math.floor(Math.random() * 100000000));
+    config_builder.with_endpoint(argv.endpoint);
+    const config = config_builder.build();
+
+    const client = new mqtt.MqttClient();
+    return client.new_connection(config);
+}
+
+async function main(argv: Args) {
+    common_args.apply_sample_arguments(argv);
+    const connection = build_connection(argv);
+
+    // force node to wait 20 seconds before killing itself, promises do not keep node alive
+    // ToDo: we can get rid of this but it requires a refactor of the native connection binding that includes
+    //    pinning the libuv event loop while the connection is active or potentially active.
+    const timer = setInterval(() => { }, 20 * 1000);
+
+    console.log("Connecting...");
+    await connection.connect()
+    console.log("Connection completed.");
+    console.log("Disconnecting...");
+    await connection.disconnect()
+    console.log("Disconnect completed.");
+
+    // Allow node to die if the promise above resolved
+    clearTimeout(timer);
+}

--- a/samples/node/cognito_connect/package.json
+++ b/samples/node/cognito_connect/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "cognito-connect",
+    "version": "1.0.0",
+    "description": "NodeJS IoT SDK v2 Cognito Connect Sample",
+    "homepage": "https://github.com/aws/aws-iot-device-sdk-js-v2",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/aws/aws-iot-device-sdk-js-v2.git"
+    },
+    "contributors": [
+        "AWS SDK Common Runtime Team <aws-sdk-common-runtime@amazon.com>"
+    ],
+    "license": "Apache-2.0",
+    "main": "./dist/index.js",
+    "scripts": {
+        "tsc": "tsc",
+        "prepare": "npm run tsc"
+    },
+    "devDependencies": {
+        "@types/node": "^10.17.50",
+        "typescript": "^4.7.4"
+    },
+    "dependencies": {
+        "aws-iot-device-sdk-v2": "file:../../..",
+        "yargs": "^16.2.0"
+    }
+}

--- a/samples/node/cognito_connect/tsconfig.json
+++ b/samples/node/cognito_connect/tsconfig.json
@@ -1,0 +1,62 @@
+{
+    "compilerOptions": {
+        /* Basic Options */
+        "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+        "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+        // "lib": [],                             /* Specify library files to be included in the compilation. */
+        // "allowJs": true,                       /* Allow javascript files to be compiled. */
+        // "checkJs": true,                       /* Report errors in .js files. */
+        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+        "declaration": true, /* Generates corresponding '.d.ts' file. */
+        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        "sourceMap": true, /* Generates corresponding '.map' file. */
+        // "outFile": "./",                       /* Concatenate and emit output to single file. */
+        "outDir": "./dist", /* Redirect output structure to the directory. */
+        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        // "composite": true,                     /* Enable project compilation */
+        // "removeComments": false,                /* Do not emit comments to output. */
+        // "noEmit": true,                        /* Do not emit outputs. */
+        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+        /* Strict Type-Checking Options */
+        "strict": true, /* Enable all strict type-checking options. */
+        "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
+        "strictNullChecks": true, /* Enable strict null checks. */
+        "strictFunctionTypes": true, /* Enable strict checking of function types. */
+        "strictBindCallApply": true, /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+        "strictPropertyInitialization": true, /* Enable strict checking of property initialization in classes. */
+        "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
+        "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
+        /* Additional Checks */
+        "noUnusedLocals": true, /* Report errors on unused locals. */
+        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+        "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+        /* Module Resolution Options */
+        // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+        // "typeRoots": [],                       /* List of folders to include type definitions from. */
+        // "types": [],                           /* Type declaration files to be included in compilation. */
+        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+        /* Source Map Options */
+        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+        /* Experimental Options */
+        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    },
+    "include": [
+        "*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/samples/util/cli_args.js
+++ b/samples/util/cli_args.js
@@ -245,6 +245,20 @@ function add_jobs_arguments(yargs) {
 }
 
 /*
+ * Arguments specific to the Cognito samples.
+ */
+function add_cognito_arguments(yargs) {
+    yargs
+        .option('cognito_identity', {
+            alias: 'i',
+            description: 'The Cognito identity ID to use to connect via Cognito',
+            type: 'string',
+            default: '',
+            required: true
+        })
+}
+
+/*
  * Handles any non-specific arguments that are relevant to all samples
  */
 function apply_sample_arguments(argv) {
@@ -386,6 +400,7 @@ exports.add_topic_message_arguments = add_topic_message_arguments;
 exports.add_shadow_arguments = add_shadow_arguments;
 exports.add_custom_authorizer_arguments = add_custom_authorizer_arguments;
 exports.add_jobs_arguments = add_jobs_arguments;
+exports.add_cognito_arguments = add_cognito_arguments;
 exports.apply_sample_arguments = apply_sample_arguments;
 exports.build_connection_from_cli_args = build_connection_from_cli_args;
 exports.build_mqtt5_client_from_cli_args = build_mqtt5_client_from_cli_args;


### PR DESCRIPTION
*Description of changes:*

Adds a sample for showing how to connect to Cognito using the CognitoCredentialsProvider, adjusts the README to include how to setup and run the sample, and adjusts CI to run new the Cognito sample in CI. Also adds a browser cognito connect sample, which points to the browser PubSub which already uses Cognito to connect.

____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
