### PR TITLE
Fix JSON pubsub parsing

### DIFF
--- a/samples/node/pub_sub/index.ts
+++ b/samples/node/pub_sub/index.ts
@@ -28,13 +28,18 @@ async function execute_session(connection: mqtt.MqttClientConnection, argv: Args
             const on_publish = async (topic: string, payload: ArrayBuffer, dup: boolean, qos: mqtt.QoS, retain: boolean) => {
                 const json = decoder.decode(payload);
                 console.log(`Publish received. topic:"${topic}" dup:${dup} qos:${qos} retain:${retain}`);
-                console.log(json);
-                const message = JSON.parse(json);
-                if (message.sequence == argv.count) {
-                    subscribed = true;
-                    if (subscribed && published) {
-                        resolve();
+                console.log(`Payload: ${json}`);
+                try {
+                    const message = JSON.parse(json);
+                    if (message.sequence == argv.count) {
+                        subscribed = true;
+                        if (subscribed && published) {
+                            resolve();
+                        }
                     }
+                }
+                catch (error) {
+                    console.log("Warning: Could not parse message as JSON...");
                 }
             }
 

--- a/samples/node/pub_sub_js/index.js
+++ b/samples/node/pub_sub_js/index.js
@@ -24,14 +24,18 @@ async function execute_session(connection, argv) {
             const on_publish = async (topic, payload, dup, qos, retain) => {
                 const json = decoder.decode(payload);
                 console.log(`Publish received. topic:"${topic}" dup:${dup} qos:${qos} retain:${retain}`);
-                console.log(json);
-                const message = JSON.parse(json);
-
-                if (message.sequence == argv.count) {
-                    subscribed = true;
-                    if (subscribed && published) {
-                        resolve();
+                console.log(`Payload: ${json}`);
+                try {
+                    const message = JSON.parse(json);
+                    if (message.sequence == argv.count) {
+                        subscribed = true;
+                        if (subscribed && published) {
+                            resolve();
+                        }
                     }
+                }
+                catch (error) {
+                    console.log("Warning: Could not parse message as JSON...");
                 }
             }
 
@@ -73,9 +77,9 @@ async function main(argv) {
     //    pinning the libuv event loop while the connection is active or potentially active.
     const timer = setInterval(() => { }, 90 * 1000);
 
-    await connection.connect().catch((error) => {console.log("Connect error: " + error); exit(-1)});
-    await execute_session(connection, argv).catch((error) => {console.log("Session error: " + error); exit(-1)});
-    await connection.disconnect().catch((error) => {console.log("Disconnect error: " + error), exit(-1)});
+    await connection.connect().catch((error) => { console.log("Connect error: " + error); exit(-1) });
+    await execute_session(connection, argv).catch((error) => { console.log("Session error: " + error); exit(-1) });
+    await connection.disconnect().catch((error) => { console.log("Disconnect error: " + error), exit(-1) });
 
     // Allow node to die if the promise above resolved
     clearTimeout(timer);


### PR DESCRIPTION
*Description of changes:*

The PubSub samples cause CI to fail if other PubSub samples in the other IoT SDKs (Java, C++, Python) are running at the same time and publishing to the same topic. This is because all the PubSub samples publish to the same topic, but the Javascript PubSub samples always assume the payload contains valid JSON data. When non-valid JSON data is received, the code throws an exception.

This PR fixes the issue by wrapping the attempt to decode the payload as JSON in a try-catch. That way if the JSON decode fails, it does not cause CI to fail and it will just ignore the non-JSON payload.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
