### PR TITLE
Export missing CrtError and bump CRT to a version that includes source

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -21,7 +21,8 @@ import {
     io,
     iot,
     mqtt,
-    mqtt5
+    mqtt5,
+    CrtError
 } from 'aws-crt/dist.browser/browser';
 
 export {
@@ -34,5 +35,6 @@ export {
     iotjobs,
     iotshadow,
     mqtt,
-    mqtt5
+    mqtt5,
+    CrtError
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,7 +25,8 @@ import {
     io,
     iot,
     mqtt,
-    mqtt5
+    mqtt5,
+    CrtError
 } from 'aws-crt';
 
 export {
@@ -38,5 +39,6 @@ export {
     iotjobs,
     iotshadow,
     mqtt,
-    mqtt5
+    mqtt5,
+    CrtError
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,9 +60,9 @@
       }
     },
     "aws-crt": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.11.tgz",
-      "integrity": "sha512-2VlPEIm1WiBZbVrMgqSVNmm3saSOYKS4iT6ltMyz0/LTbaO1sBz6eXxz+im5dvvavgyjcqOuyyBn0rGTqkStZw==",
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.13.tgz",
+      "integrity": "sha512-mcFxe4FS5duooayuUP9/fwD8GTaxgQDxmJJ5jocwj+Vq4IE9HfJqVDvTbEOttCHATFuieSXvOy6A1c0QqEmL2A==",
       "requires": {
         "@aws-sdk/util-utf8-browser": "^3.109.0",
         "@httptoolkit/websocket-stream": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "@aws-sdk/util-utf8-browser": "^3.109.0",
-    "aws-crt": "^1.15.11"
+    "aws-crt": "^1.15.13"
   }
 }


### PR DESCRIPTION
* Export missing CrtError type
* Update CRT to a version that includes the typescript source in the npm package

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
