### PR TITLE
Mqtt5 shared subscription sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
     - name: run MQTT5 PubSub sample
       run: |
         python3 ./aws-iot-device-sdk-js-v2/utils/run_sample_ci.py --file ./aws-iot-device-sdk-js-v2/.github/workflows/ci_run_mqtt5_pubsub_cfg.json
+    - name: run MQTT5 Shared Subscription sample
+      run: |
+        python3 ./aws-iot-device-sdk-js-v2/utils/run_sample_ci.py --file ./aws-iot-device-sdk-js-v2/.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
 
   # check that docs can still build
   check-docs:

--- a/.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
+++ b/.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
@@ -1,0 +1,26 @@
+{
+    "language": "Javascript",
+    "sample_file": "./aws-iot-device-sdk-js-v2/samples/node/pub_sub_mqtt5",
+    "sample_region": "us-east-1",
+    "sample_main_class": "",
+    "arguments": [
+        {
+            "name": "--endpoint",
+            "secret": "ci/endpoint"
+        },
+        {
+            "name": "--cert",
+            "secret": "ci/mqtt5/us/mqtt5_thing/cert",
+            "filename": "tmp_certificate.pem"
+        },
+        {
+            "name": "--key",
+            "secret": "ci/mqtt5/us/mqtt5_thing/key",
+            "filename": "tmp_key.pem"
+        },
+        {
+            "name": "--is_ci",
+            "data": "true"
+        }
+    ]
+}

--- a/.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
+++ b/.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
@@ -1,6 +1,6 @@
 {
     "language": "Javascript",
-    "sample_file": "./aws-iot-device-sdk-js-v2/samples/node/pub_sub_mqtt5",
+    "sample_file": "./aws-iot-device-sdk-js-v2/samples/node/shared_subscription",
     "sample_region": "us-east-1",
     "sample_main_class": "",
     "arguments": [

--- a/samples/README.md
+++ b/samples/README.md
@@ -5,6 +5,7 @@
 * [Node: Pub/Sub](./node/pub_sub/README.md)
 * [Pub/Sub JS](./node/pub_sub_js/README.md)
 * [Browser: Pub/Sub](./browser/pub_sub/README.md)
+* [Node: MQTT5 Shared Subscription](./node/shared_subscription/README.md)
 * [Node: Basic Connect](./node/basic_connect/README.md)
 * [Node: Websocket Connect](./node/websocket_connect/README.md)
 * [Node: PKCS#11 Connect](./node/pkcs11_connect/README.md)

--- a/samples/README.md
+++ b/samples/README.md
@@ -6,6 +6,7 @@
 * [Pub/Sub JS](./node/pub_sub_js/README.md)
 * [Browser: Pub/Sub](./browser/pub_sub/README.md)
 * [Node: MQTT5 Shared Subscription](./node/shared_subscription/README.md)
+* [Browser: MQTT5 Shared Subscription](./browser/shared_subscription/README.md)
 * [Node: Basic Connect](./node/basic_connect/README.md)
 * [Node: Websocket Connect](./node/websocket_connect/README.md)
 * [Node: PKCS#11 Connect](./node/pkcs11_connect/README.md)

--- a/samples/browser/shared_subscription/README.md
+++ b/samples/browser/shared_subscription/README.md
@@ -1,4 +1,4 @@
-# Node: MQTT5 Shared Subscription
+# Browser: MQTT5 PubSub
 
 [**Return to main sample list**](../../README.md)
 
@@ -77,23 +77,8 @@ Note that in a real application, you may want to avoid the use of wildcards in y
 
 ## How to run
 
-To Run this sample using a direct MQTT connection with a key and certificate, use the following command:
+To run this sample you need to have a Cognito identity pool setup that can be used for making IoT connections. To see how to setup a Cognito identity pool, please refer to this page on the [AWS documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/tutorial-create-identity-pool.html).
 
-``` sh
-npm install
-node dist/index.js --endpoint <endpoint> --cert <file> --key <file>
-```
+Once you have a Cognito identity pool, you need to fill in the credentials in the `browser/shared_subscription/settings.js` file with your AWS endpoint, AWS region, and Cognito identity pool. You can fill in the other settings if you want/need as well. Run `npm install` in the `browser/shared_subscription` folder to build the sample. open `browser/shared_subscription/index.html` to run the sample in your browser!
 
-You can also pass a Certificate Authority file (CA) if your certificate and key combination requires it:
-
-``` sh
-npm install
-node dist/index.js --endpoint <endpoint> --cert <file> --key <file> --ca_file <path to root CA>
-```
-
-Finally, you can also set the Shared Subscription group identifier and topic with `--group_identifier` and `--topic` respectively:
-
-``` sh
-npm install
-node dist/index.js --endpoint <endpoint> --cert <file> --key <file> --group_identifier <group identifier> --topic <topic>
-```
+If configured correctly, it should make three MQTT5 clients, two of them will subscribe to a shared topic, and then the remaining MQTT5 client will make a number of publishes. Finally, once the set number of publishes have been met, the sample will unsubscribe the two MQTT5 clients and disconnect all of the MQTT5 clients.

--- a/samples/browser/shared_subscription/README.md
+++ b/samples/browser/shared_subscription/README.md
@@ -4,20 +4,20 @@
 
 This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
-for AWS IoT to send and receive messages through an MQTT connection using MQTT5 using a Shared Subscription.
+for AWS IoT to send and receive messages over an MQTT5 connection using a shared subscription.
 
 MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](https://github.com/awslabs/aws-crt-nodejs/blob/main/MQTT5-UserGuide.md).
 
 Note: MQTT5 support is currently in **developer preview**. We encourage feedback at all times, but feedback during the preview window is especially valuable in shaping the final product. During the preview period we may make backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
 
-Shared Subscriptions allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to processed.
+[Shared Subscriptions](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901250) allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to be processed.
 
-Shared Subscriptions rely on what is called a group identifier, which tells the MQTT5 broker/server which IoT devices are in what group. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
+Shared Subscriptions rely on a group identifier, which tells the MQTT5 broker/server which IoT devices tp treat as a group for message distribution. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
 * `$share`: Tells the MQTT5 broker/server that the device is subscribing to a Shared Subscription.
-* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. THis is the group of MQTT5 clients that will be worked through as part of the round-robin when a message comes in. For example: `my-iot-group`.
+* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. Messages published to a matching topic will be distributed round-robin amongst the group.
 * `<topic>`: The topic that the Shared Subscription is for. Messages published to this topic will be processed in a round-robin fashion. For example, `test/topic`.
 
-As mentioned, Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
+Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
 * Message 1 -> Client one
 * Message 2 -> Client two
 * Message 3 -> Client three

--- a/samples/browser/shared_subscription/index.html
+++ b/samples/browser/shared_subscription/index.html
@@ -1,0 +1,16 @@
+<!--
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ * SPDX-License-Identifier: Apache-2.0.
+-->
+<html>
+
+<head>
+    <meta charset="UTF-8">
+</head>
+
+<body>
+    <div id="console"></div>
+    <script src="dist/index.js"></script>
+</body>
+
+</html>

--- a/samples/browser/shared_subscription/index.ts
+++ b/samples/browser/shared_subscription/index.ts
@@ -1,0 +1,267 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import {mqtt5, auth, iot} from "aws-iot-device-sdk-v2";
+import jquery = require("jquery");
+import {once} from "events";
+import { fromCognitoIdentityPool } from "@aws-sdk/credential-providers";
+import { CognitoIdentityCredentials } from "@aws-sdk/credential-provider-cognito-identity/dist-types/fromCognitoIdentity"
+// @ts-ignore
+import Settings = require('./settings');
+import {toUtf8} from "@aws-sdk/util-utf8-browser";
+
+// MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
+// preview window is especially valuable in shaping the final product.  During the preview period we may make
+// backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
+
+const $: JQueryStatic = jquery;
+
+function log(msg: string) {
+    let now = new Date();
+    $('#console').append(`<pre>${now.toString()}: ${msg}</pre>`);
+}
+
+// AWSCognitoCredentialOptions. The credentials options used to create AWSCongnitoCredentialProvider.
+interface AWSCognitoCredentialOptions
+{
+    IdentityPoolId : string,
+    Region: string
+}
+
+// AWSCognitoCredentialsProvider. The AWSCognitoCredentialsProvider implements AWS.CognitoIdentityCredentials.
+class AWSCognitoCredentialsProvider extends auth.CredentialsProvider{
+    private options: AWSCognitoCredentialOptions;
+    private cachedCredentials? : CognitoIdentityCredentials;
+
+    constructor(options: AWSCognitoCredentialOptions, expire_interval_in_ms? : number)
+    {
+        super();
+        this.options = options;
+
+        setInterval(async ()=>{
+            await this.refreshCredentials();
+        },expire_interval_in_ms?? 3600*1000);
+    }
+
+    getCredentials() : auth.AWSCredentials {
+        return {
+            aws_access_id: this.cachedCredentials?.accessKeyId ?? "",
+            aws_secret_key: this.cachedCredentials?.secretAccessKey ?? "",
+            aws_sts_token: this.cachedCredentials?.sessionToken,
+            aws_region: this.options.Region
+        }
+    }
+
+    async refreshCredentials()  {
+        log('Fetching Cognito credentials');
+        this.cachedCredentials = await fromCognitoIdentityPool({
+            // Required. The unique identifier for the identity pool from which an identity should be
+            // retrieved or generated.
+            identityPoolId: this.options.IdentityPoolId,
+            clientConfig: { region: this.options.Region },
+        })();
+    }
+}
+
+// For the purposes of this sample, we need to associate certain variables with a particular MQTT5 client
+// and to do so we use this class to hold all the data for a particular client used in the sample.
+class SampleMqtt5Client {
+    client? : mqtt5.Mqtt5Client;
+    name? : string;
+    messagesReceived : number = 0;
+    messagesExpected : number = 0;
+    messagePromise? : Promise<void>;
+    _messagePromiseResolve : any;
+    _messagePromiseReject : any;
+
+    // Sets up the MQTT5 sample client using direct MQTT5 via mTLS with the passed input data.
+    public setupMqtt5Client(
+        provider: AWSCognitoCredentialsProvider,
+        input_endpoint : string, input_region: string, input_count : number, input_clientId : string, input_clientName : string)
+    {
+        this.name = input_clientName;
+
+        let wsConfig : iot.WebsocketSigv4Config = {
+            credentialsProvider: provider,
+            region: input_region
+        }
+        let builder: iot.AwsIotMqtt5ClientConfigBuilder = iot.AwsIotMqtt5ClientConfigBuilder.newWebsocketMqttBuilderWithSigv4Auth(
+            input_endpoint,
+            wsConfig
+        )
+        builder.withConnectProperties({
+            clientId: input_clientId,
+            keepAliveIntervalSeconds: 120
+        })
+        this.client = new mqtt5.Mqtt5Client(builder.build());
+
+        this.messagesReceived = 0;
+        this.messagesExpected = input_count;
+
+        let promiseResolve : any;
+        let promiseReject : any;
+        this.messagePromise = new Promise<void>(function(resolve, reject){
+            promiseResolve = resolve;
+            promiseReject = reject;
+        });
+        this._messagePromiseResolve = promiseResolve;
+        this._messagePromiseReject = promiseReject;
+
+        // Invoked when the client has an error
+        this.client.on('error', (error) => {
+            log("[" + this.name + "] Error: " + error.toString());
+        });
+
+        // Invoked when the client gets a message/publish on a subscribed topic
+        this.client.on("messageReceived",(eventData: mqtt5.MessageReceivedEvent) : void => {
+            log("[" + this.name + "]: Received a publish");
+            if (eventData.message.topicName) {
+                log("\tPublish received on topic: " + eventData.message.topicName);
+            }
+            if (eventData.message.payload) {
+                log("\tMessage: " + toUtf8(new Uint8Array(eventData.message.payload as ArrayBuffer)));
+            }
+
+            this.messagesReceived += 1;
+            if (this.messagesReceived >= this.messagesExpected) {
+                this._messagePromiseResolve();
+            }
+        });
+
+        // Invoked when the client connects successfully to the endpoint
+        this.client.on('connectionSuccess', (eventData: mqtt5.ConnectionSuccessEvent) => {
+            log("[" + this.name + "]: Connection success");
+        });
+
+        // Invoked when the client fails to connect to the endpoint
+        this.client.on('connectionFailure', (eventData: mqtt5.ConnectionFailureEvent) => {
+            log("[" + this.name + "]: Connection failed with error: " + eventData.error.toString());
+        });
+
+        // Invoked when the client becomes disconnected
+        this.client.on('disconnection', (eventData: mqtt5.DisconnectionEvent) => {
+            log("[" + this.name + "]: Disconnected");
+
+            if (eventData.disconnect) {
+                if (eventData.disconnect.reasonCode == mqtt5.DisconnectReasonCode.SharedSubscriptionsNotSupported) {
+                    log(
+                        "[" + this.name + "]: Shared Subscriptions not supported!" +
+                        "\nThis sample will not work unless the endpoint being connected to has Shared Subscriptions support.");
+                }
+            }
+        });
+
+        // Invoked when the client stops
+        this.client.on('stopped', (eventData: mqtt5.StoppedEvent) => {
+            log("[" + this.name + "]: Stopped");
+        });
+    }
+
+    // Helper function to make sample code a little cleaner
+    public async startClient() {
+        const connectionSuccess = once(this.client as mqtt5.Mqtt5Client, "connectionSuccess");
+        this.client?.start();
+        await connectionSuccess;
+    }
+
+    // Helper function to make sample code a little cleaner
+    public async stopClient() {
+        const stopped = once(this.client as mqtt5.Mqtt5Client, "stopped");
+        this.client?.stop();
+        await stopped;
+    }
+}
+
+async function runSample() {
+
+    // Pull data from the command line
+    let input_endpoint : string = Settings.AWS_IOT_ENDPOINT;
+    let input_region : string = Settings.AWS_REGION;
+    let input_clientId : string = Settings.INPUT_CLIENT_ID;
+    let input_topic : string = Settings.INPUT_TOPIC;
+    let input_count : number = Settings.INPUT_COUNT;
+    let input_message : string = Settings.INPUT_MESSAGE;
+    let input_groupIdentifier : string = Settings.INPUT_GROUP_IDENTIFIER;
+    let input_cognitoIdentityPoolId = Settings.AWS_COGNITO_IDENTITY_POOL_ID;
+    // Construct the shared topic
+    let input_shared_topic : string = "$share/" + input_groupIdentifier + "/" + input_topic;
+
+    /** Set up the credentialsProvider */
+    const provider = new AWSCognitoCredentialsProvider({
+        IdentityPoolId: input_cognitoIdentityPoolId,
+        Region: input_region});
+    /** Make sure the credential provider fetched before setup the connection */
+    await provider.refreshCredentials();
+
+    // Create the MQTT5 clients: one publisher and two subscribers
+    let publisher : SampleMqtt5Client = new SampleMqtt5Client()
+    publisher.setupMqtt5Client(provider, input_endpoint, input_region, input_count, input_clientId + "1", "Publisher");
+    let subscriber_one : SampleMqtt5Client = new SampleMqtt5Client()
+    subscriber_one.setupMqtt5Client(provider, input_endpoint, input_region, input_count, input_clientId + "2", "Subscriber One");
+    let subscriber_two : SampleMqtt5Client = new SampleMqtt5Client()
+    subscriber_two.setupMqtt5Client(provider, input_endpoint, input_region, input_count, input_clientId + "3", "Subscriber Two");
+
+    try
+    {
+        // Connect all the clients
+        await publisher.startClient();
+        await subscriber_one.startClient();
+        await subscriber_two.startClient();
+
+        // Subscribe to the shared topic on the two subscribers
+        await subscriber_one.client?.subscribe({subscriptions: [{qos: mqtt5.QoS.AtLeastOnce, topicFilter: input_shared_topic }]});
+        log("[" + subscriber_one.name + "]: Subscribed");
+        await subscriber_two.client?.subscribe({subscriptions: [{qos: mqtt5.QoS.AtLeastOnce, topicFilter: input_shared_topic }]});
+        log("[" + subscriber_two.name + "]: Subscribed");
+
+        // Publish using the publisher client
+        let publishPacket : mqtt5.PublishPacket = {
+            qos: mqtt5.QoS.AtLeastOnce,
+            topicName: input_topic,
+            payload: input_message
+        };
+        if (input_count > 0) {
+            let count = 0;
+            while (count++ < input_count) {
+                publishPacket.payload = input_message + ": " + count;
+                await publisher.client?.publish(publishPacket);
+                log("[" + publisher.name + "]: Published");
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+            // Make sure all the messages were gotten on the subscribers
+            await subscriber_one.messagePromise;
+            await subscriber_two.messagePromise;
+        } else {
+            log("Skipping publishing messages due to message count being zero...");
+        }
+
+        // Unsubscribe from the shared topic on the two subscribers
+        await subscriber_one.client?.unsubscribe({topicFilters: [ input_shared_topic ]});
+        log("[" + subscriber_one.name + "]: Unsubscribed");
+        await subscriber_two.client?.unsubscribe({topicFilters: [ input_shared_topic ]});
+        log("[" + subscriber_two.name + "]: Unsubscribed");
+
+        // Disconnect all the clients
+        await publisher.stopClient();
+        await subscriber_one.stopClient();
+        await subscriber_two.stopClient();
+    }
+    finally {
+        // Close all the clients
+        publisher.client?.close();
+        subscriber_one.client?.close();
+        subscriber_two.client?.close();
+        log("Sample Complete!");
+    }
+}
+
+async function main(){
+    await runSample();
+    log('Leaving');
+}
+
+$(document).ready(() => {
+    main();
+});

--- a/samples/browser/shared_subscription/index.ts
+++ b/samples/browser/shared_subscription/index.ts
@@ -12,10 +12,6 @@ import { CognitoIdentityCredentials } from "@aws-sdk/credential-provider-cognito
 import Settings = require('./settings');
 import {toUtf8} from "@aws-sdk/util-utf8-browser";
 
-// MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
-// preview window is especially valuable in shaping the final product.  During the preview period we may make
-// backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
-
 const $: JQueryStatic = jquery;
 
 function log(msg: string) {

--- a/samples/browser/shared_subscription/package.json
+++ b/samples/browser/shared_subscription/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "mqtt5",
+  "version": "1.0.0",
+  "description": "Publish/Subscribe sample for AWS IoT Browser SDK",
+  "homepage": "https://github.com/aws/aws-iot-device-sdk-js-v2",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws/aws-iot-device-sdk-js-v2.git"
+  },
+  "contributors": [
+    "AWS SDK Common Runtime Team <aws-sdk-common-runtime@amazon.com>"
+  ],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/awslabs/aws-iot-device-sdk-js-v2/issues"
+  },
+  "browser": "./dist/index.js",
+  "scripts": {
+    "webpack": "webpack --mode=development",
+    "prepare": "npm run webpack",
+    "build": "webpack --mode=production --node-env=production",
+    "build:dev": "webpack --mode=development",
+    "build:prod": "webpack --mode=production --node-env=production",
+    "watch": "webpack --watch"
+  },
+  "main": "./index.js",
+  "devDependencies": {
+    "@types/jquery": "^3.3.31",
+    "node-polyfill-webpack-plugin": "^1.1.4",
+    "source-map-loader": "^4.0.0",
+    "ts-loader": "^9.3.1",
+    "typescript": "^4.7.4",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0"
+  },
+  "dependencies": {
+    "aws-iot-device-sdk-v2": "file:../../..",
+    "@aws-sdk/credential-providers": "^3.226.0",
+    "jquery": "^3.5.0",
+    "util": "^0.12.4"
+  }
+}

--- a/samples/browser/shared_subscription/package.json
+++ b/samples/browser/shared_subscription/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mqtt5",
   "version": "1.0.0",
-  "description": "Publish/Subscribe sample for AWS IoT Browser SDK",
+  "description": "Shared Subscription sample for AWS IoT Browser SDK",
   "homepage": "https://github.com/aws/aws-iot-device-sdk-js-v2",
   "repository": {
     "type": "git",

--- a/samples/browser/shared_subscription/settings.js
+++ b/samples/browser/shared_subscription/settings.js
@@ -1,0 +1,8 @@
+export const AWS_REGION = "<your region>";
+export const AWS_IOT_ENDPOINT = "<your endpoint>";
+export const AWS_COGNITO_IDENTITY_POOL_ID = "<your cognito identity pool id>";
+export const INPUT_CLIENT_ID = "test-" + Math.floor(Math.random() * 100000000);
+export const INPUT_MESSAGE = "Hello World!"
+export const INPUT_TOPIC = "test/topic"
+export const INPUT_COUNT = 10;
+export const INPUT_GROUP_IDENTIFIER = "javascript-browser-sample"

--- a/samples/browser/shared_subscription/tsconfig.json
+++ b/samples/browser/shared_subscription/tsconfig.json
@@ -1,0 +1,64 @@
+{
+    "compilerOptions": {
+        /* Basic Options */
+        "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+        "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+        // "lib": [],                             /* Specify library files to be included in the compilation. */
+        // "allowJs": true,                       /* Allow javascript files to be compiled. */
+        // "checkJs": true,                       /* Report errors in .js files. */
+        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+        "declaration": true, /* Generates corresponding '.d.ts' file. */
+        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        "sourceMap": true, /* Generates corresponding '.map' file. */
+        // "outFile": "./",                       /* Concatenate and emit output to single file. */
+        "outDir": "./dist", /* Redirect output structure to the directory. */
+        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        // "composite": true,                     /* Enable project compilation */
+        // "removeComments": false,                /* Do not emit comments to output. */
+        // "noEmit": true,                        /* Do not emit outputs. */
+        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+        /* Strict Type-Checking Options */
+        "strict": true, /* Enable all strict type-checking options. */
+        "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
+        "strictNullChecks": true, /* Enable strict null checks. */
+        "strictFunctionTypes": true, /* Enable strict checking of function types. */
+        "strictBindCallApply": true, /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+        "strictPropertyInitialization": true, /* Enable strict checking of property initialization in classes. */
+        "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
+        "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
+        /* Additional Checks */
+        "noUnusedLocals": true, /* Report errors on unused locals. */
+        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+        "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+        /* Module Resolution Options */
+        // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        "paths": {
+            "aws-iot-device-sdk-v2": ["node_modules/aws-iot-device-sdk-v2/dist/browser"]
+        },                           // A series of entries which re-map imports to lookup locations relative to the 'baseUrl'.
+        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+        // "typeRoots": [],                       /* List of folders to include type definitions from. */
+        // "types": [],                           /* Type declaration files to be included in compilation. */
+        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+        /* Source Map Options */
+        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+        /* Experimental Options */
+        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    },
+    "include": [
+        "*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/samples/browser/shared_subscription/tsconfig.json
+++ b/samples/browser/shared_subscription/tsconfig.json
@@ -3,22 +3,9 @@
         /* Basic Options */
         "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
         "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-        // "lib": [],                             /* Specify library files to be included in the compilation. */
-        // "allowJs": true,                       /* Allow javascript files to be compiled. */
-        // "checkJs": true,                       /* Report errors in .js files. */
-        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
         "declaration": true, /* Generates corresponding '.d.ts' file. */
-        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
         "sourceMap": true, /* Generates corresponding '.map' file. */
-        // "outFile": "./",                       /* Concatenate and emit output to single file. */
         "outDir": "./dist", /* Redirect output structure to the directory. */
-        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-        // "composite": true,                     /* Enable project compilation */
-        // "removeComments": false,                /* Do not emit comments to output. */
-        // "noEmit": true,                        /* Do not emit outputs. */
-        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
         /* Strict Type-Checking Options */
         "strict": true, /* Enable all strict type-checking options. */
         "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -30,29 +17,13 @@
         "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
         /* Additional Checks */
         "noUnusedLocals": true, /* Report errors on unused locals. */
-        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
         "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
         /* Module Resolution Options */
-        // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         "paths": {
             "aws-iot-device-sdk-v2": ["node_modules/aws-iot-device-sdk-v2/dist/browser"]
         },                           // A series of entries which re-map imports to lookup locations relative to the 'baseUrl'.
-        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-        // "typeRoots": [],                       /* List of folders to include type definitions from. */
-        // "types": [],                           /* Type declaration files to be included in compilation. */
-        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-        /* Source Map Options */
-        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-        /* Experimental Options */
-        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     },
     "include": [
         "*.ts"

--- a/samples/browser/shared_subscription/webpack.config.js
+++ b/samples/browser/shared_subscription/webpack.config.js
@@ -1,0 +1,20 @@
+const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+
+module.exports = {
+  entry: "./index.ts",
+  devtool: "source-map",
+  target: "web",
+  output: {
+    filename: "index.js",
+  },
+  resolve: {
+    extensions: [".tsx", ".ts", ".js", ".json"],
+  },
+  module: {
+    rules: [
+      // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
+      { test: /\.tsx?$/, use: ["ts-loader"], exclude: /node_modules/ },
+    ],
+  },
+  plugins: [new NodePolyfillPlugin()],
+};

--- a/samples/node/shared_subscription/README.md
+++ b/samples/node/shared_subscription/README.md
@@ -1,0 +1,97 @@
+# Node: MQTT5 Shared Subscription
+
+This sample uses the
+[Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
+for AWS IoT to send and receive messages through an MQTT connection using MQTT5 using a Shared Subscription.
+
+MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](https://github.com/awslabs/aws-crt-nodejs/blob/main/MQTT5-UserGuide.md).
+
+Note: MQTT5 support is currently in **developer preview**. We encourage feedback at all times, but feedback during the preview window is especially valuable in shaping the final product. During the preview period we may make backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
+
+Shared Subscriptions allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to processed.
+
+Shared Subscriptions rely on what is called a group identifier, which tells the MQTT5 broker/server which IoT devices are in what group. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
+* `$share`: Tells the MQTT5 broker/server that the device is subscribing to a Shared Subscription.
+* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. THis is the group of MQTT5 clients that will be worked through as part of the round-robin when a message comes in. For example: `my-iot-group`.
+* `<topic>`: The topic that the Shared Subscription is for. Messages published to this topic will be processed in a round-robin fashion. For example, `test/topic`.
+
+As mentioned, Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
+* Message 1 -> Client one
+* Message 2 -> Client two
+* Message 3 -> Client three
+* Message 4 -> Client one
+* Message 5 -> Client two
+* etc...
+
+Your IoT Core Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect, subscribe, publish, and receive. Below is a sample policy that can be used on your IoT Core Thing that will allow this sample to run as intended.
+
+<details>
+<summary>(see sample policy)</summary>
+<pre>
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Publish",
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/topic",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$share/*/test/topic"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Subscribe"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/test/topic",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$share/*/test/topic"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Connect"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+      ]
+    }
+  ]
+}
+</pre>
+
+Replace with the following with the data from your AWS account:
+* `<region>`: The AWS IoT Core region where you created your AWS IoT Core thing you wish to use with this sample. For example `us-east-1`.
+* `<account>`: Your AWS IoT Core account ID. This is the set of numbers in the top right next to your AWS account name when using the AWS IoT Core website.
+
+Note that in a real application, you may want to avoid the use of wildcards in your ClientID or use them selectively. Please follow best practices when working with AWS on production applications using the SDK. Also, for the purposes of this sample, please make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
+
+</details>
+
+## How to run
+
+To Run this sample using a direct MQTT connection with a key and certificate, use the following command:
+
+``` sh
+npm install
+node dist/index.js --endpoint <endpoint> --cert <file> --key <file>
+```
+
+You can also pass a Certificate Authority file (CA) if your certificate and key combination requires it:
+
+``` sh
+npm install
+node dist/index.js --endpoint <endpoint> --cert <file> --key <file> --ca_file <path to root CA>
+```
+
+Finally, you can also set the Shared Subscription group identifier and topic with `--group_identifier` and `--topic` respectively:
+
+``` sh
+npm install
+node dist/index.js --endpoint <endpoint> --cert <file> --key <file> --group_identifier <group identifier> --topic <topic>
+```

--- a/samples/node/shared_subscription/README.md
+++ b/samples/node/shared_subscription/README.md
@@ -4,20 +4,20 @@
 
 This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
-for AWS IoT to send and receive messages through an MQTT connection using MQTT5 using a Shared Subscription.
+for AWS IoT to send and receive messages over an MQTT5 connection using a shared subscription.
 
 MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](https://github.com/awslabs/aws-crt-nodejs/blob/main/MQTT5-UserGuide.md).
 
 Note: MQTT5 support is currently in **developer preview**. We encourage feedback at all times, but feedback during the preview window is especially valuable in shaping the final product. During the preview period we may make backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
 
-Shared Subscriptions allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to processed.
+[Shared Subscriptions](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901250) allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to be processed.
 
-Shared Subscriptions rely on what is called a group identifier, which tells the MQTT5 broker/server which IoT devices are in what group. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
+Shared Subscriptions rely on a group identifier, which tells the MQTT5 broker/server which IoT devices tp treat as a group for message distribution. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
 * `$share`: Tells the MQTT5 broker/server that the device is subscribing to a Shared Subscription.
-* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. THis is the group of MQTT5 clients that will be worked through as part of the round-robin when a message comes in. For example: `my-iot-group`.
+* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. Messages published to a matching topic will be distributed round-robin amongst the group.
 * `<topic>`: The topic that the Shared Subscription is for. Messages published to this topic will be processed in a round-robin fashion. For example, `test/topic`.
 
-As mentioned, Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
+Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
 * Message 1 -> Client one
 * Message 2 -> Client two
 * Message 3 -> Client three

--- a/samples/node/shared_subscription/index.ts
+++ b/samples/node/shared_subscription/index.ts
@@ -1,0 +1,270 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import {mqtt5, iot} from "aws-iot-device-sdk-v2";
+import {ICrtError} from "aws-crt";
+import {once} from "events";
+import { toUtf8 } from '@aws-sdk/util-utf8-browser';
+
+// MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
+// preview window is especially valuable in shaping the final product.  During the preview period we may make
+// backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
+
+// The relative path is '../../util/cli_args' from here, but the compiled javascript file gets put one level
+// deeper inside the 'dist' folder
+const common_args = require('../../../util/cli_args');
+
+type Args = { [index: string]: any };
+const yargs = require('yargs');
+
+// For the purposes of this sample, we need to associate certain variables with a particular MQTT5 client
+// and to do so we use this class to hold all the data for a particular client used in the sample.
+class SampleMqtt5Client {
+    client? : mqtt5.Mqtt5Client;
+    name? : string;
+    messagesReceived : number = 0;
+    messagesExpected : number = 0;
+    messagePromise? : Promise<void>;
+    _messagePromiseResolve : any;
+    _messagePromiseReject : any;
+
+    // Sets up the MQTT5 sample client using direct MQTT5 via mTLS with the passed input data.
+    public setupMqtt5Client(
+        input_endpoint : string, input_cert : string, input_key : string, input_ca : string,
+        input_clientId : string, input_count : number, input_clientName : string, input_isCi : boolean)
+    {
+        this.name = input_clientName;
+
+        let builder : iot.AwsIotMqtt5ClientConfigBuilder = iot.AwsIotMqtt5ClientConfigBuilder.newDirectMqttBuilderWithMtlsFromPath(
+            input_endpoint,
+            input_cert,
+            input_key
+        );
+        builder.withConnectProperties({
+            keepAliveIntervalSeconds: 1200,
+            clientId: input_clientId
+        });
+        if (input_ca != null && input_ca != undefined) {
+            builder.withCertificateAuthorityFromPath(undefined, input_ca);
+        }
+        this.client = new mqtt5.Mqtt5Client(builder.build());
+
+        this.messagesReceived = 0;
+        this.messagesExpected = input_count;
+
+        let promiseResolve : any;
+        let promiseReject : any;
+        this.messagePromise = new Promise<void>(function(resolve, reject){
+            promiseResolve = resolve;
+            promiseReject = reject;
+        });
+        this._messagePromiseResolve = promiseResolve;
+        this._messagePromiseReject = promiseReject;
+
+        // Invoked when the client has an error
+        this.client.on('error', (error: ICrtError) => {
+            console.log("[" + this.name + "] Error: " + error.toString());
+        });
+
+        // Invoked when the client gets a message/publish on a subscribed topic
+        this.client.on("messageReceived",(eventData: mqtt5.MessageReceivedEvent) : void => {
+            console.log("[" + this.name + "]: Received a publish");
+            if (eventData.message.topicName) {
+                console.log("\tPublish received on topic: " + eventData.message.topicName);
+            }
+            if (eventData.message.payload) {
+                console.log("\tMessage: " + toUtf8(new Uint8Array(eventData.message.payload as ArrayBuffer)));
+            }
+
+            this.messagesReceived += 1;
+            if (this.messagesReceived >= this.messagesExpected) {
+                this._messagePromiseResolve();
+            }
+        });
+
+        // Invoked when the client connects successfully to the endpoint
+        this.client.on('connectionSuccess', (eventData: mqtt5.ConnectionSuccessEvent) => {
+            console.log("[" + this.name + "]: Connection success");
+        });
+
+        // Invoked when the client fails to connect to the endpoint
+        this.client.on('connectionFailure', (eventData: mqtt5.ConnectionFailureEvent) => {
+            console.log("[" + this.name + "]: Connection failed with error: " + eventData.error.toString());
+        });
+
+        // Invoked when the client becomes disconnected
+        this.client.on('disconnection', (eventData: mqtt5.DisconnectionEvent) => {
+            console.log("[" + this.name + "]: Disconnected");
+
+            if (eventData.disconnect) {
+                if (eventData.disconnect.reasonCode == mqtt5.DisconnectReasonCode.SharedSubscriptionsNotSupported) {
+                    console.log("[" + this.name + "]: Shared Subscriptions not supported. Stopping sample...");
+                    if (input_isCi == true) {
+                        process.exit(0);
+                    } else {
+                        process.exit(-1);
+                    }
+                }
+            }
+        });
+
+        // Invoked when the client stops
+        this.client.on('stopped', (eventData: mqtt5.StoppedEvent) => {
+            console.log("[" + this.name + "]: Stopped");
+        });
+    }
+
+    // Helper function to make sample code a little cleaner
+    public async startClient() {
+        const connectionSuccess = once(this.client as mqtt5.Mqtt5Client, "connectionSuccess");
+        this.client?.start();
+        await connectionSuccess;
+    }
+
+    // Helper function to make sample code a little cleaner
+    public async stopClient() {
+        const stopped = once(this.client as mqtt5.Mqtt5Client, "stopped");
+        this.client?.stop();
+        await stopped;
+    }
+}
+
+async function runSample(args : any) {
+
+    // Pull data from the command line
+    let input_endpoint : string = args.endpoint;
+    let input_cert : string = args.cert;
+    let input_key : string = args.key;
+    let input_ca : string = args.ca_file;
+    let input_clientId : string = args.client_id;
+    let input_count : number = args.count;
+    let input_topic : string = args.topic;
+    let input_message : string = args.message;
+    let input_groupIdentifier : string = args.group_identifier;
+    let input_isCi : boolean = args.is_ci != undefined && args.is_ci != null;
+
+    // Ensure data was pulled from the command line or is set to default values
+    if (input_count == null || input_count == undefined) {
+        input_count = 10;
+    }
+    if (input_clientId == null || input_clientId == undefined) {
+        input_clientId = "test-" + Math.floor(Math.random() * 100000000)
+    }
+    if (input_topic == null || input_topic == undefined) {
+        input_topic = "test/topic";
+    }
+    if (input_message == null || input_message == undefined) {
+        input_message = "Hello World!";
+    }
+    if (input_groupIdentifier == null || input_groupIdentifier == undefined) {
+        input_groupIdentifier = "javascript-sample";
+    }
+
+    // If this is CI, append a UUID to the topic
+    if (input_isCi) {
+        input_topic += "/" + Math.floor(Math.random() * 100000000);
+    }
+
+    // Construct the shared topic
+    let input_shared_topic : string = "$share/" + input_groupIdentifier + "/" + input_topic;
+
+    // Make sure the message count is even
+    if (input_count % 2 != 0) {
+        console.log("'--count' is an odd number. '--count' must be even or zero for this sample.");
+        process.exit(-1);
+    }
+
+    // Create the MQTT5 clients: one publisher and two subscribers
+    let publisher : SampleMqtt5Client = new SampleMqtt5Client()
+    publisher.setupMqtt5Client(
+        input_endpoint, input_cert, input_key, input_ca, input_clientId + "1", input_count, "Publisher", input_isCi);
+    let subscriber_one : SampleMqtt5Client = new SampleMqtt5Client()
+    subscriber_one.setupMqtt5Client(
+        input_endpoint, input_cert, input_key, input_ca, input_clientId + "2", input_count/2, "Subscriber One", input_isCi);
+    let subscriber_two : SampleMqtt5Client = new SampleMqtt5Client()
+    subscriber_two.setupMqtt5Client(
+        input_endpoint, input_cert, input_key, input_ca, input_clientId + "3", input_count/2, "Subscriber Two", input_isCi);
+
+    try
+    {
+        // Connect all the clients
+        await publisher.startClient();
+        await subscriber_one.startClient();
+        await subscriber_two.startClient();
+
+        // Subscribe to the shared topic on the two subscribers
+        await subscriber_one.client?.subscribe({subscriptions: [{qos: mqtt5.QoS.AtLeastOnce, topicFilter: input_shared_topic }]});
+        console.log("[" + subscriber_one.name + "]: Subscribed");
+        await subscriber_two.client?.subscribe({subscriptions: [{qos: mqtt5.QoS.AtLeastOnce, topicFilter: input_shared_topic }]});
+        console.log("[" + subscriber_two.name + "]: Subscribed");
+
+        // Publish using the publisher client
+        let publishPacket : mqtt5.PublishPacket = {
+            qos: mqtt5.QoS.AtLeastOnce,
+            topicName: input_topic,
+            payload: input_message
+        };
+        if (input_count > 0) {
+            let count = 0;
+            while (count++ < input_count) {
+                publishPacket.payload = input_message + ": " + count;
+                await publisher.client?.publish(publishPacket);
+                console.log("[" + publisher.name + "]: Published");
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+            // Make sure all the messages were gotten on the subscribers
+            await subscriber_one.messagePromise;
+            await subscriber_two.messagePromise;
+        } else {
+            console.log("Skipping publishing messages due to message count being zero...");
+        }
+
+        // Unsubscribe from the shared topic on the two subscribers
+        await subscriber_one.client?.unsubscribe({topicFilters: [ input_shared_topic ]});
+        console.log("[" + subscriber_one.name + "]: Unsubscribed");
+        await subscriber_two.client?.unsubscribe({topicFilters: [ input_shared_topic ]});
+        console.log("[" + subscriber_two.name + "]: Unsubscribed");
+
+        // Disconnect all the clients
+        await publisher.stopClient();
+        await subscriber_one.stopClient();
+        await subscriber_two.stopClient();
+    }
+    finally {
+        // Close all the clients
+        publisher.client?.close();
+        subscriber_one.client?.close();
+        subscriber_two.client?.close();
+    }
+    console.log("Complete!");
+}
+
+/* Register command line arguments */
+yargs.command('*', false, (yargs: any) => {
+    common_args.add_universal_arguments(yargs);
+    common_args.add_common_mqtt_arguments(yargs);
+    common_args.add_direct_tls_connect_arguments(yargs);
+    yargs.option('count', {
+        description: '<number>: The number of messages to publish (optional, default=10)',
+        type: 'int',
+        required: false,
+        default: 10
+    })
+    .option('group_identifier', {
+        description: '<string>: The group identifier to use in the shared subscription (optional, default=javascript-sample)',
+        type: 'string',
+        required: false,
+        default: 'javascript-sample'
+    })
+}, main).parse();
+
+async function main(args : Args){
+    // make it wait as long as possible once the promise completes we'll turn it off.
+    const timer = setTimeout(() => {}, 2147483647);
+    await runSample(args);
+    clearTimeout(timer);
+    process.exit(0);
+}
+

--- a/samples/node/shared_subscription/index.ts
+++ b/samples/node/shared_subscription/index.ts
@@ -8,10 +8,6 @@ import {ICrtError} from "aws-crt";
 import {once} from "events";
 import { toUtf8 } from '@aws-sdk/util-utf8-browser';
 
-// MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
-// preview window is especially valuable in shaping the final product.  During the preview period we may make
-// backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
-
 // The relative path is '../../util/cli_args' from here, but the compiled javascript file gets put one level
 // deeper inside the 'dist' folder
 const common_args = require('../../../util/cli_args');

--- a/samples/node/shared_subscription/package.json
+++ b/samples/node/shared_subscription/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "shared-subscription",
+    "version": "1.0.0",
+    "description": "NodeJS IoT SDK v2 MQTT5 Shared Subscription Sample",
+    "homepage": "https://github.com/aws/aws-iot-device-sdk-js-v2",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/aws/aws-iot-device-sdk-js-v2.git"
+    },
+    "contributors": [
+        "AWS SDK Common Runtime Team <aws-sdk-common-runtime@amazon.com>"
+    ],
+    "license": "Apache-2.0",
+    "main": "./dist/index.js",
+    "scripts": {
+        "tsc": "tsc",
+        "prepare": "npm run tsc"
+    },
+    "devDependencies": {
+        "@types/node": "^10.17.50",
+        "typescript": "^4.7.4"
+    },
+    "dependencies": {
+        "aws-iot-device-sdk-v2": "file:../../..",
+        "yargs": "^16.2.0"
+    }
+}

--- a/samples/node/shared_subscription/tsconfig.json
+++ b/samples/node/shared_subscription/tsconfig.json
@@ -1,0 +1,62 @@
+{
+    "compilerOptions": {
+        /* Basic Options */
+        "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+        "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+        // "lib": [],                             /* Specify library files to be included in the compilation. */
+        // "allowJs": true,                       /* Allow javascript files to be compiled. */
+        // "checkJs": true,                       /* Report errors in .js files. */
+        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+        "declaration": true, /* Generates corresponding '.d.ts' file. */
+        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        "sourceMap": true, /* Generates corresponding '.map' file. */
+        // "outFile": "./",                       /* Concatenate and emit output to single file. */
+        "outDir": "./dist", /* Redirect output structure to the directory. */
+        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        // "composite": true,                     /* Enable project compilation */
+        // "removeComments": false,                /* Do not emit comments to output. */
+        // "noEmit": true,                        /* Do not emit outputs. */
+        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+        /* Strict Type-Checking Options */
+        "strict": true, /* Enable all strict type-checking options. */
+        "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
+        "strictNullChecks": true, /* Enable strict null checks. */
+        "strictFunctionTypes": true, /* Enable strict checking of function types. */
+        "strictBindCallApply": true, /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+        "strictPropertyInitialization": true, /* Enable strict checking of property initialization in classes. */
+        "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
+        "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
+        /* Additional Checks */
+        "noUnusedLocals": true, /* Report errors on unused locals. */
+        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+        "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+        /* Module Resolution Options */
+        // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+        // "typeRoots": [],                       /* List of folders to include type definitions from. */
+        // "types": [],                           /* Type declaration files to be included in compilation. */
+        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+        /* Source Map Options */
+        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+        /* Experimental Options */
+        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    },
+    "include": [
+        "*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"    
+    ]
+}

--- a/samples/node/shared_subscription/tsconfig.json
+++ b/samples/node/shared_subscription/tsconfig.json
@@ -3,22 +3,9 @@
         /* Basic Options */
         "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
         "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-        // "lib": [],                             /* Specify library files to be included in the compilation. */
-        // "allowJs": true,                       /* Allow javascript files to be compiled. */
-        // "checkJs": true,                       /* Report errors in .js files. */
-        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
         "declaration": true, /* Generates corresponding '.d.ts' file. */
-        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
         "sourceMap": true, /* Generates corresponding '.map' file. */
-        // "outFile": "./",                       /* Concatenate and emit output to single file. */
         "outDir": "./dist", /* Redirect output structure to the directory. */
-        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-        // "composite": true,                     /* Enable project compilation */
-        // "removeComments": false,                /* Do not emit comments to output. */
-        // "noEmit": true,                        /* Do not emit outputs. */
-        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
         /* Strict Type-Checking Options */
         "strict": true, /* Enable all strict type-checking options. */
         "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -30,27 +17,9 @@
         "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
         /* Additional Checks */
         "noUnusedLocals": true, /* Report errors on unused locals. */
-        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
         "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
         /* Module Resolution Options */
-        // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-        // "typeRoots": [],                       /* List of folders to include type definitions from. */
-        // "types": [],                           /* Type declaration files to be included in compilation. */
-        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-        /* Source Map Options */
-        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-        /* Experimental Options */
-        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     },
     "include": [
         "*.ts"

--- a/samples/node/shared_subscription/tsconfig.json
+++ b/samples/node/shared_subscription/tsconfig.json
@@ -57,6 +57,6 @@
     ],
     "exclude": [
         "node_modules",
-        "dist"    
+        "dist"
     ]
 }


### PR DESCRIPTION
*Description of changes:*

Adds a MQTT5 Shared Subscription sample to both NodeJS and the Browser. Also adds the NodeJS sample to CI, where it will just skip if the client becomes disconnected due to a lack of shared subscription support. The browser version prints an error to the log if shared subscription support is not available.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
