### PR TITLE
Add a minified PubSub sample

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -5,6 +5,7 @@
 * [Node: Pub/Sub](./node/pub_sub/README.md)
 * [Pub/Sub JS](./node/pub_sub_js/README.md)
 * [Browser: Pub/Sub](./browser/pub_sub/README.md)
+* [Browser: Pub/Sub Minified](./browser/pub_sub_minified/README.md)
 * [Node: MQTT5 Shared Subscription](./node/shared_subscription/README.md)
 * [Browser: MQTT5 Shared Subscription](./browser/shared_subscription/README.md)
 * [Node: Basic Connect](./node/basic_connect/README.md)

--- a/samples/browser/pub_sub_minified/README.md
+++ b/samples/browser/pub_sub_minified/README.md
@@ -60,6 +60,8 @@ To run this sample you need to have a Cognito identity pool setup that can be us
 
 Once you have a Cognito identity pool, you need to fill in the credentials in the `browser/pub_sub_minified/settings.js` file with your AWS endpoint, AWS region, and Cognito identity pool. Run `npm install` in the `browser/pub_sub` folder to build the sample. open `browser/pub_sub_minified/index.html` to run the sample in your browser! If configured correctly, it should connect to AWS IoT Core, subscribe to a topic, and then start receiving the messages it publishes to the topic it's subscribed to.
 
+**Note**: The Webpack minimizer requires Node 10.13.0 or higher and NPM 5.3.8 or higher.
+
 ### How to change the minimizer on and off
 
 You can turn the minimizer on and off by modifying `browser/pub_sub_minified/webpack.config.js`. Open `browser/pub_sub_minified/webpack.config.js` and find the following, which should be around line 22:

--- a/samples/browser/pub_sub_minified/README.md
+++ b/samples/browser/pub_sub_minified/README.md
@@ -1,0 +1,76 @@
+# Browser: PubSub Minified
+
+[**Return to main sample list**](../../README.md)
+
+This sample is exactly the same as the [PubSub](../pub_sub/README.md) browser sample, but it is setup to use a Webpack minimizer. The sample is minified with Webpack using the [TerserWrapper plugin](https://webpack.js.org/plugins/terser-webpack-plugin/), which makes the source code harder to read, decreases the total file size, and provides a little extra security due to minimized code.
+
+**Note**: While minifying makes the code more secure by making it harder to read, it does not necessarily hide secrets or sensitive information, like the AWS credentials in `settings.js` in this sample. The use of `settings.js` is for illustration and easy of use purposes only. Please always follow best practices for development and security whenever developing applications.
+
+Your IoT Core Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect, subscribe, publish, and receive. Below is a sample policy that can be used on your IoT Core Thing that will allow this sample to run as intended.
+
+<details>
+<summary>(see sample policy)</summary>
+<pre>
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Publish",
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/topic"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Subscribe"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/test/topic"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Connect"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+      ]
+    }
+  ]
+}
+</pre>
+
+Replace with the following with the data from your AWS account:
+* `<region>`: The AWS IoT Core region where you created your AWS IoT Core thing you wish to use with this sample. For example `us-east-1`.
+* `<account>`: Your AWS IoT Core account ID. This is the set of numbers in the top right next to your AWS account name when using the AWS IoT Core website.
+
+Note that in a real application, you may want to avoid the use of wildcards in your ClientID or use them selectively. Please follow best practices when working with AWS on production applications using the SDK. Also, for the purposes of this sample, please make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.
+
+</details>
+
+## How to run
+
+To run this sample you need to have a Cognito identity pool setup that can be used for making IoT connections. To see how to setup a Cognito identity pool, please refer to this page on the [AWS documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/tutorial-create-identity-pool.html).
+
+Once you have a Cognito identity pool, you need to fill in the credentials in the `browser/pub_sub_minified/settings.js` file with your AWS endpoint, AWS region, and Cognito identity pool. Run `npm install` in the `browser/pub_sub` folder to build the sample. open `browser/pub_sub_minified/index.html` to run the sample in your browser! If configured correctly, it should connect to AWS IoT Core, subscribe to a topic, and then start receiving the messages it publishes to the topic it's subscribed to.
+
+### How to change the minimizer on and off
+
+You can turn the minimizer on and off by modifying `browser/pub_sub_minified/webpack.config.js`. Open `browser/pub_sub_minified/webpack.config.js` and find the following, which should be around line 22:
+
+~~~js
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin()]
+  }
+~~~
+
+You can change `minimize: true` according to whether or not you want to minimize the code for that particular build. To turn the minimizer off, change it to `minimize: false`, and then run `npm install`. Likewise, to turn it on, change it to `minimize: true` and run `npm install`.
+
+You can check the results of the minimizer and confirm whether it is on or off by looking at `browser/pub_sub_minified/dist/index.js`. When the minimizer is on, all of the code should be heavily compressed and extremely hard to read.

--- a/samples/browser/pub_sub_minified/README.md
+++ b/samples/browser/pub_sub_minified/README.md
@@ -4,7 +4,7 @@
 
 This sample is exactly the same as the [PubSub](../pub_sub/README.md) browser sample, but it is setup to use a Webpack minimizer. The sample is minified with Webpack using the [TerserWrapper plugin](https://webpack.js.org/plugins/terser-webpack-plugin/), which makes the source code harder to read, decreases the total file size, and provides a little extra security due to minimized code.
 
-**Note**: While minifying makes the code more secure by making it harder to read, it does not necessarily hide secrets or sensitive information, like the AWS credentials in `settings.js` in this sample. The use of `settings.js` is for illustration and easy of use purposes only. Please always follow best practices for development and security whenever developing applications.
+**Note**: While minifying makes the code more secure by making it harder to read, it does not necessarily hide secrets or sensitive information, like the AWS credentials in `settings.js` in this sample. The use of `settings.js` is for demonstration purposes only. Please follow best practices for development and security whenever developing applications.
 
 Your IoT Core Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect, subscribe, publish, and receive. Below is a sample policy that can be used on your IoT Core Thing that will allow this sample to run as intended.
 
@@ -62,7 +62,7 @@ Once you have a Cognito identity pool, you need to fill in the credentials in th
 
 **Note**: The Webpack minimizer requires Node 10.13.0 or higher and NPM 5.3.8 or higher.
 
-### How to change the minimizer on and off
+### How to turn the minimizer on and off
 
 You can turn the minimizer on and off by modifying `browser/pub_sub_minified/webpack.config.js`. Open `browser/pub_sub_minified/webpack.config.js` and find the following, which should be around line 22:
 

--- a/samples/browser/pub_sub_minified/index.html
+++ b/samples/browser/pub_sub_minified/index.html
@@ -1,0 +1,16 @@
+<!--
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+-->
+<html>
+
+<head>
+    <meta charset="UTF-8">
+</head>
+
+<body>
+    <div id="console"></div>
+    <script src="dist/index.js"></script>
+</body>
+
+</html>

--- a/samples/browser/pub_sub_minified/index.ts
+++ b/samples/browser/pub_sub_minified/index.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import { mqtt, iot, auth } from "aws-iot-device-sdk-v2";
+import * as AWS from "aws-sdk";
+const Settings = require("./settings");
+const $ = require("jquery");
+
+function log(msg: string) {
+  $("#console").append(`<pre>${msg}</pre>`);
+}
+
+
+/**
+* AWSCognitoCredentialOptions. The credentials options used to create AWSCongnitoCredentialProvider.
+*/
+interface AWSCognitoCredentialOptions
+{
+  IdentityPoolId : string,
+  Region: string
+}
+
+/**
+* AWSCognitoCredentialsProvider. The AWSCognitoCredentialsProvider implements AWS.CognitoIdentityCredentials.
+*
+*/
+export class AWSCognitoCredentialsProvider extends auth.CredentialsProvider{
+  private options: AWSCognitoCredentialOptions;
+  private source_provider : AWS.CognitoIdentityCredentials;
+  private aws_credentials : auth.AWSCredentials;
+  constructor(options: AWSCognitoCredentialOptions, expire_interval_in_ms? : number)
+  {
+    super();
+    this.options = options;
+    AWS.config.region = options.Region;
+    this.source_provider = new AWS.CognitoIdentityCredentials({
+        IdentityPoolId: options.IdentityPoolId
+    });
+    this.aws_credentials = 
+    {
+        aws_region: options.Region,
+        aws_access_id : this.source_provider.accessKeyId,
+        aws_secret_key: this.source_provider.secretAccessKey,
+        aws_sts_token: this.source_provider.sessionToken
+    }
+
+    setInterval(async ()=>{
+        await this.refreshCredentialAsync();
+    },expire_interval_in_ms?? 3600*1000);
+  }
+
+  getCredentials(){
+      return this.aws_credentials;
+  }
+
+  async refreshCredentialAsync()
+  {
+    return new Promise<AWSCognitoCredentialsProvider>((resolve, reject) => {
+        this.source_provider.get((err)=>{
+            if(err)
+            {
+                reject("Failed to get cognito credentials.")
+            }
+            else
+            {
+                this.aws_credentials.aws_access_id = this.source_provider.accessKeyId;
+                this.aws_credentials.aws_secret_key = this.source_provider.secretAccessKey;
+                this.aws_credentials.aws_sts_token = this.source_provider.sessionToken;
+                this.aws_credentials.aws_region = this.options.Region;
+                resolve(this);
+            }
+        });
+    });
+  }
+}
+
+async function connect_websocket(provider: auth.CredentialsProvider) {
+  return new Promise<mqtt.MqttClientConnection>((resolve, reject) => {
+    let config = iot.AwsIotMqttConnectionConfigBuilder.new_builder_for_websocket()
+        .with_clean_session(true)
+        .with_client_id(`pub_sub_sample(${new Date()})`)
+        .with_endpoint(Settings.AWS_IOT_ENDPOINT)
+        .with_credential_provider(provider)
+        .with_use_websockets()
+        .with_keep_alive_seconds(30)
+        .build();
+
+    log("Connecting websocket...");
+    const client = new mqtt.MqttClient();
+
+    const connection = client.new_connection(config);
+    connection.on("connect", (session_present) => {
+      resolve(connection);
+    });
+    connection.on("interrupt", (error) => {
+      log(`Connection interrupted: error=${error}`);
+    });
+    connection.on("resume", (return_code, session_present) => {
+      log(`Resumed: rc: ${return_code} existing session: ${session_present}`);
+    });
+    connection.on("disconnect", () => {
+      log("Disconnected");
+    });
+    connection.on("error", (error) => {
+      reject(error);
+    });
+    connection.connect();
+  });
+}
+
+async function main() {
+  /** Set up the credentialsProvider */
+  const provider = new AWSCognitoCredentialsProvider({
+          IdentityPoolId: Settings.AWS_COGNITO_IDENTITY_POOL_ID, 
+          Region: Settings.AWS_REGION});
+  /** Make sure the credential provider fetched before setup the connection */
+  await provider.refreshCredentialAsync();
+
+
+  connect_websocket(provider)
+  .then((connection) => {
+      connection
+        .subscribe(
+          "/test/me/senpai",
+          mqtt.QoS.AtLeastOnce,
+          (topic, payload, dup, qos, retain) => {
+            const decoder = new TextDecoder("utf8");
+            let message = decoder.decode(new Uint8Array(payload));
+            log(`Message received: topic=${topic} message=${message}`);
+            /** The sample is used to demo long-running web service. 
+             * Uncomment the following line to see how disconnect behaves.*/
+            // connection.disconnect();
+          }
+        )
+        .then((subscription) => {
+          log(`start publish`)
+          var msg_count = 0;
+          connection.publish(subscription.topic, `NOTICE ME {${msg_count}}`, subscription.qos);
+          /** The sample is used to demo long-running web service. The sample will keep publishing the message every minute.*/
+          setInterval( ()=>{
+            msg_count++;
+            const msg = `NOTICE ME {${msg_count}}`;
+            connection.publish(subscription.topic, msg, subscription.qos);
+          }, 60000);
+        });
+    })
+    .catch((reason) => {
+      log(`Error while connecting: ${reason}`);
+    });
+}
+
+main();

--- a/samples/browser/pub_sub_minified/package.json
+++ b/samples/browser/pub_sub_minified/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "pub_sub_minified",
+  "version": "1.0.0",
+  "description": "Minified Publish/Subscribe sample for AWS IoT Browser SDK",
+  "homepage": "https://github.com/aws/aws-iot-device-sdk-js-v2",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws/aws-iot-device-sdk-js-v2.git"
+  },
+  "contributors": [
+    "AWS SDK Common Runtime Team <aws-sdk-common-runtime@amazon.com>"
+  ],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/awslabs/aws-iot-device-sdk-js-v2/issues"
+  },
+  "browser": "./dist/index.js",
+  "scripts": {
+    "webpack": "webpack --mode=development",
+    "prepare": "cd ../../.. && npm install && cd samples/browser/pub_sub && npm run webpack",
+    "build": "webpack --mode=production --node-env=production",
+    "build:dev": "webpack --mode=development",
+    "build:prod": "webpack --mode=production --node-env=production",
+    "watch": "webpack --watch"
+  },
+  "main": "./index.js",
+  "devDependencies": {
+    "@types/jquery": "^3.3.31",
+    "node-polyfill-webpack-plugin": "^1.1.4",
+    "source-map-loader": "^4.0.0",
+    "terser-webpack-plugin": "^5.3.8",
+    "ts-loader": "^9.3.1",
+    "typescript": "^4.7.4",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0"
+  },
+  "dependencies": {
+    "aws-iot-device-sdk-v2": "file:../../..",
+    "aws-sdk": "^2.585.0",
+    "jquery": "^3.5.0"
+  }
+}

--- a/samples/browser/pub_sub_minified/settings.js
+++ b/samples/browser/pub_sub_minified/settings.js
@@ -1,0 +1,3 @@
+export const AWS_REGION = "<your region>";
+export const AWS_IOT_ENDPOINT = "<your endpoint>";
+export const AWS_COGNITO_IDENTITY_POOL_ID = "<your cognito identity pool id>";

--- a/samples/browser/pub_sub_minified/tsconfig.json
+++ b/samples/browser/pub_sub_minified/tsconfig.json
@@ -1,0 +1,64 @@
+{
+    "compilerOptions": {
+        /* Basic Options */
+        "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+        "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+        // "lib": [],                             /* Specify library files to be included in the compilation. */
+        // "allowJs": true,                       /* Allow javascript files to be compiled. */
+        // "checkJs": true,                       /* Report errors in .js files. */
+        // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+        "declaration": true, /* Generates corresponding '.d.ts' file. */
+        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        "sourceMap": true, /* Generates corresponding '.map' file. */
+        // "outFile": "./",                       /* Concatenate and emit output to single file. */
+        "outDir": "./dist", /* Redirect output structure to the directory. */
+        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+        // "composite": true,                     /* Enable project compilation */
+        // "removeComments": false,                /* Do not emit comments to output. */
+        // "noEmit": true,                        /* Do not emit outputs. */
+        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+        // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+        /* Strict Type-Checking Options */
+        "strict": true, /* Enable all strict type-checking options. */
+        "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
+        "strictNullChecks": true, /* Enable strict null checks. */
+        "strictFunctionTypes": true, /* Enable strict checking of function types. */
+        "strictBindCallApply": true, /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+        "strictPropertyInitialization": true, /* Enable strict checking of property initialization in classes. */
+        "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
+        "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
+        /* Additional Checks */
+        "noUnusedLocals": true, /* Report errors on unused locals. */
+        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+        "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+        /* Module Resolution Options */
+        // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        "paths": {
+            "aws-iot-device-sdk-v2": ["node_modules/aws-iot-device-sdk-v2/dist/browser"]
+        },                           // A series of entries which re-map imports to lookup locations relative to the 'baseUrl'.
+        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+        // "typeRoots": [],                       /* List of folders to include type definitions from. */
+        // "types": [],                           /* Type declaration files to be included in compilation. */
+        // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+        /* Source Map Options */
+        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+        /* Experimental Options */
+        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    },
+    "include": [
+        "*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/samples/browser/pub_sub_minified/webpack.config.js
+++ b/samples/browser/pub_sub_minified/webpack.config.js
@@ -1,0 +1,25 @@
+const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
+
+module.exports = {
+  entry: "./index.ts",
+  devtool: "source-map",
+  target: "web",
+  output: {
+    filename: "index.js",
+  },
+  resolve: {
+    extensions: [".tsx", ".ts", ".js", ".json"],
+  },
+  module: {
+    rules: [
+      // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
+      { test: /\.tsx?$/, use: ["ts-loader"], exclude: /node_modules/ },
+    ],
+  },
+  plugins: [new NodePolyfillPlugin()],
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin()]
+  }
+};


### PR DESCRIPTION
*Issue #, if available:*

Closes #146

*Description of changes:*

Shows how to setup the PubSub sample with a Webpack minimizer. This is added as a separate sample because the minimizer has a higher NodeJS requirement than the SDK, so to keep the ordinary PubSub at the same NodeJS version, it is added separately. 

____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
