### PR TITLE
Fix the Greengrass Discovery error print

### DIFF
--- a/samples/node/basic_discovery/index.ts
+++ b/samples/node/basic_discovery/index.ts
@@ -211,7 +211,7 @@ async function main(argv: Args) {
             console.log('Complete!');
         })
         .catch((reason) => {
-            console.log(`DISCOVERY SAMPLE FAILED: ${reason}`);
+            console.log(`DISCOVERY SAMPLE FAILED: ${JSON.stringify(reason)}`);
         });
 
     // Allow node to die if the promise above resolved


### PR DESCRIPTION
*Issue #, if available:*

Fixes #164

*Description of changes:*

Converts the basic discovery error report information into a string using `JSON.stringify` so the error code that is returned with the error is visible.

Before this PR:
~~~
DISCOVERY SAMPLE FAILED: Error: Discovery failed (headers: [object Object])
~~~

After this PR:
~~~
DISCOVERY SAMPLE FAILED: {"response_code":404}
~~~

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
