### PR TITLE
Fix CRT shared object unload crash in node worker threads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,9 +1201,9 @@
       "dev": true
     },
     "aws-crt": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.18.tgz",
-      "integrity": "sha512-N66E/3tvkvFjGIcCXf4tZBakvGCUBMdxkJ7l1Hnwr2biW5AL55uTI7ww+P003XXxP1Njm494EHdC+UmYvZeXYw==",
+      "version": "1.15.19",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.19.tgz",
+      "integrity": "sha512-lMLYlWU0zfdXyqoOR23Z9NObgPFU/yyGnGOILyvVAsGu1+nfrJjBHGgE8rhI08wNOv3dxna9aAME46cBYiQhDg==",
       "requires": {
         "@aws-sdk/util-utf8-browser": "^3.109.0",
         "@httptoolkit/websocket-stream": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/jest": "^27.0.1",
     "@types/node": "^10.17.54",
     "@types/puppeteer": "^5.4.7",
+    "@types/ws": "8.5.4",
     "cmake-js": "^6.3.0",
     "jest": "^27.2.1",
     "jest-puppeteer": "^5.0.4",
@@ -42,6 +43,6 @@
   },
   "dependencies": {
     "@aws-sdk/util-utf8-browser": "^3.109.0",
-    "aws-crt": "^1.15.18"
+    "aws-crt": "^1.15.19"
   }
 }


### PR DESCRIPTION
* Update CRT to fix shared object unload crash
* pin @types/ws since the latest version is broken 

Addresses crash issue discussed in https://github.com/aws/aws-iot-device-sdk-js-v2/discussions/360

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
