### PR TITLE
Update CRT to bring in a potential eventstream crash fix for Greengrass regression testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,9 +1201,9 @@
       "dev": true
     },
     "aws-crt": {
-      "version": "1.15.19",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.19.tgz",
-      "integrity": "sha512-lMLYlWU0zfdXyqoOR23Z9NObgPFU/yyGnGOILyvVAsGu1+nfrJjBHGgE8rhI08wNOv3dxna9aAME46cBYiQhDg==",
+      "version": "1.15.20",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.15.20.tgz",
+      "integrity": "sha512-BH70ccRssb281Xky/KsKvi7N1P1RHQUzWw+LFPDZ+JJd1AlmWRADsvHWrshV95FkeDQMASBxXdh8Ag+BhoPErg==",
       "requires": {
         "@aws-sdk/util-utf8-browser": "^3.109.0",
         "@httptoolkit/websocket-stream": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "@aws-sdk/util-utf8-browser": "^3.109.0",
-    "aws-crt": "^1.15.19"
+    "aws-crt": "^1.15.20"
   }
 }


### PR DESCRIPTION



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
