### PR TITLE
use square bracket for array

### DIFF
--- a/samples/util/cli_args.js
+++ b/samples/util/cli_args.js
@@ -138,7 +138,7 @@ function add_proxy_arguments(yargs) {
 function add_common_websocket_arguments(yargs, is_required=false) {
     yargs
         .option('signing_region', {
-            alias: ('s', 'region'),
+            alias: ['s', 'region'],
             description: 'If you specify --signing_region then you will use websockets to connect. This' +
                 'is the region that will be used for computing the Sigv4 signature.  This region must match the' +
                 'AWS region in your endpoint.',


### PR DESCRIPTION
according to the doc, key should be a string or array of strings https://yargs.js.org/docs/#api-reference-optionkey-opt

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
