### PR TITLE
Update typescript version in DA tests

### DIFF
--- a/deviceadvisor/tests/mqtt_connect/package.json
+++ b/deviceadvisor/tests/mqtt_connect/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "../../../",

--- a/deviceadvisor/tests/mqtt_publish/package.json
+++ b/deviceadvisor/tests/mqtt_publish/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "../../../"

--- a/deviceadvisor/tests/mqtt_subscribe/package.json
+++ b/deviceadvisor/tests/mqtt_subscribe/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "../../../"

--- a/deviceadvisor/tests/shadow_update/package.json
+++ b/deviceadvisor/tests/shadow_update/package.json
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@types/node": "^10.17.50",
-        "typescript": "^3.9.7"
+        "typescript": "^4.7.4"
     },
     "dependencies": {
         "aws-iot-device-sdk-v2": "../../../"


### PR DESCRIPTION
Device Advisor tests print some strange errors:

```
> mqtt_connect@1.0.0 tsc
> tsc

../../../node_modules/@types/babel__traverse/index.d.ts(68,50): error TS1005: ']' expected.
../../../node_modules/@types/babel__traverse/index.d.ts(68,53): error TS1005: ';' expected.
../../../node_modules/@types/babel__traverse/index.d.ts(68,58): error TS1005: ';' expected.
../../../node_modules/@types/babel__traverse/index.d.ts(68,70): error TS1011: An element access expression should take an argument.
../../../node_modules/@types/babel__traverse/index.d.ts(68,83): error TS1005: ';' expected.
../../../node_modules/@types/babel__traverse/index.d.ts(68,84): error TS1128: Declaration or statement expected.
../../../node_modules/@types/babel__traverse/index.d.ts(68,88): error TS1128: Declaration or statement expected.
npm ERR! code 2
npm ERR! path /Users/runner/work/aws-iot-device-sdk-js-v2/aws-iot-device-sdk-js-v2/aws-iot-device-sdk-js-v2/deviceadvisor/tests/mqtt_connect
npm ERR! command failed
npm ERR! command sh -c npm run tsc
```

Updating the typescript version to the same version the other parts of SDK use fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
