### PR TITLE
update aws-crt, which now supports 32bit VSOCK ports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -535,24 +535,6 @@
         "safe-buffer": "^5.1.2",
         "ws": "*",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "20.10.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-          "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        },
-        "@types/ws": {
-          "version": "8.5.10",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-          "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
-          "requires": {
-            "@types/node": "*"
-          }
-        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -964,8 +946,7 @@
     "@types/node": {
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "@types/prettier": {
       "version": "2.7.3",
@@ -992,7 +973,6 @@
       "version": "8.5.4",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
       "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1138,9 +1118,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-crt": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.20.0.tgz",
-      "integrity": "sha512-K7b7vVroFEvYr3J17Q1R8MOXEowPrWVQRiFqRZHJXwdrPT6ICmnGzt0ZoGj3nZzp1KbDjSKIggdoq4VwsGmyYQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.20.1.tgz",
+      "integrity": "sha512-Vs2Sz5LGgCDflmaPL2VPtsqc3sGGQfevU6NSeX0egPnI7R9NeNH1j3KFEhSuhRyzfynwBHJO7jM5hYiEm+GiPw==",
       "requires": {
         "@aws-sdk/util-utf8-browser": "^3.109.0",
         "@httptoolkit/websocket-stream": "^6.0.1",
@@ -1152,9 +1132,9 @@
       }
     },
     "axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
+      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -4640,11 +4620,6 @@
         }
       }
     },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -4960,9 +4935,9 @@
       }
     },
     "ws": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
-      "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ=="
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "@aws-sdk/util-utf8-browser": "^3.109.0",
-    "aws-crt": "^1.20.0"
+    "aws-crt": "^1.20.1"
   }
 }


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-c-io/issues/576

adds support for 32bit ports, to support VSOCK

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
