### PR TITLE
Minor GitHub workflow changes

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -13,7 +13,5 @@ jobs:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
             message: |
-                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
-                     Comments on closed issues are hard for our team to see. 
-                     If you need more assistance, please either tag a team member or open a new issue that references this one. 
-                     If you wish to keep having a conversation with other community members under this issue feel free to do so.
+                    This issue is now closed. Comments on closed issues are hard for our team to see. 
+                    If you need more assistance, please open a new issue that references this one. 

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -33,8 +33,8 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 2
-        days-before-close: 5
+        days-before-stale: 10
+        days-before-close: 4
         days-before-ancient: 36500
 
         # If you don't want to mark a issue as being ancient based on a


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We received some customer feedback that our stale issue message is too loud and too full of emoji, and our stale issue timings are too strict. This PR corrects both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
