### PR TITLE
make 'echoMessage failure test' conditional

### DIFF
--- a/lib/echotestrpc.spec.ts
+++ b/lib/echotestrpc.spec.ts
@@ -423,7 +423,7 @@ conditional_test(hasEchoServerEnvironment())('echoMessage failure test - client 
     client.close();
 });
 
-test('echoMessage failure test - server side internal service error', async () => {
+conditional_test(hasEchoServerEnvironment())('echoMessage failure test - server side internal service error', async () => {
     let client: echo_rpc.Client = echo_rpc.createClient(makeGoodConfig());
 
     await client.connect();


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-js-v2/issues/486

*Description of changes:*
Make the `echoMessage failure test` a conditional_test. Don't have it run locally because it needs to connect to the echo server environment to succeed. 
```ts
hostName: process.env.AWS_TEST_EVENT_STREAM_ECHO_SERVER_HOST ?? "",
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
