### PR TITLE
Use node-16 for Mac OS arm64 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.56
+  BUILDER_VERSION: v0.9.62
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-iot-device-sdk-js-v2

--- a/builder.json
+++ b/builder.json
@@ -7,6 +7,16 @@
     "+packages": [
         "maven"
     ],
+    "hosts": {
+        "macos": {
+            "architectures": {
+                "arm64": {
+                    "_comment": "Mac OS (arm64) has only experimental support for Node v15 and earlier, so stick to Node v16, see Node v15 docs: https://github.com/nodejs/node/blob/v15.x/BUILDING.md#platform-list",
+                    "!imports": [ "node-16" ]
+                }
+            }
+        }
+    },
     "deps_dir": "deps",
 
     "build_steps": [


### PR DESCRIPTION
*Issue #, if available:*

macos job currently fails in CI.

*Description of changes:*

Prior to Node v16, Mac OS arm64 has only experimental support (for example, see [Node v15 docs](https://github.com/nodejs/node/blob/v15.x/BUILDING.md#platform-list)). So, using node-16 for Mac OS arm64 job seems the right solution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
