### PR TITLE
Use the actual aws-crt dependency version to make docs

### DIFF
--- a/make-docs.sh
+++ b/make-docs.sh
@@ -11,7 +11,7 @@ if [ ! -d build/docs/aws-crt-nodejs ]; then
     git clone --single-branch https://github.com/awslabs/aws-crt-nodejs.git build/docs/aws-crt-nodejs
 fi
 
-CRT_VERSION=`npm view aws-crt version`
+CRT_VERSION=`node -p "require('./package.json').dependencies['aws-crt']"`
 pushd build/docs/aws-crt-nodejs
 git fetch
 git checkout "v$CRT_VERSION"


### PR DESCRIPTION
*Issue #, if available:*

The current command for getting the CRT version is `npm view aws-crt version`. It returns the latest available version, not the actual dependency used.

*Description of changes:*

Parse `aws-crt` version from `package.json`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
