### PR TITLE
Set client ID in samples

### DIFF
--- a/samples/browser/pub_sub_mqtt5/index.ts
+++ b/samples/browser/pub_sub_mqtt5/index.ts
@@ -78,6 +78,10 @@ function createClient(provider: AWSCognitoCredentialsProvider) : mqtt5.Mqtt5Clie
         wsConfig
     )
 
+    builder.withConnectProperties({
+        clientId: "test-" + Math.floor(Math.random() * 100000000)
+    });
+
     let client : mqtt5.Mqtt5Client = new mqtt5.Mqtt5Client(builder.build());
 
     client.on('error', (error) => {

--- a/samples/browser/react_sample/src/PubSub5.tsx
+++ b/samples/browser/react_sample/src/PubSub5.tsx
@@ -78,6 +78,9 @@ function createClient(provider: AWSCognitoCredentialsProvider) : mqtt5.Mqtt5Clie
         AWS_IOT_ENDPOINT,
         wsConfig
     )
+    builder.withConnectProperties({
+        clientId: "test-" + Math.floor(Math.random() * 100000000)
+    });
 
     let client : mqtt5.Mqtt5Client = new mqtt5.Mqtt5Client(builder.build());
 

--- a/samples/node/pub_sub_electron_node/Main.ts
+++ b/samples/node/pub_sub_electron_node/Main.ts
@@ -94,7 +94,7 @@ function createClientConfig(isWebsocket: boolean): mqtt5.Mqtt5ClientConfig {
 
   builder.withConnectProperties({
     keepAliveIntervalSeconds: 1200,
-    clientId: "test-client"
+    clientId: "test-client" + Math.floor(Math.random() * 100000000)
   });
 
   return builder.build();

--- a/samples/node/pub_sub_mqtt5/index.ts
+++ b/samples/node/pub_sub_mqtt5/index.ts
@@ -37,9 +37,15 @@ yargs.command('*', false, (yargs: any) => {
         type: 'string',
         required: false
     })
+    .option('client_id', {
+        alias: 'C',
+        description: 'Client ID for MQTT connection.',
+        type: 'string',
+        required: false
+    })
 }, main).parse();
 
-function creatClientConfig(args : any) : mqtt5.Mqtt5ClientConfig {
+function createClientConfig(args : any) : mqtt5.Mqtt5ClientConfig {
     let builder : iot.AwsIotMqtt5ClientConfigBuilder | undefined = undefined;
 
     if (args.key && args.cert) {
@@ -61,7 +67,9 @@ function creatClientConfig(args : any) : mqtt5.Mqtt5ClientConfig {
         );
     }
 
+
     builder.withConnectProperties({
+        clientId: args.client_id || "test-" + Math.floor(Math.random() * 100000000),
         keepAliveIntervalSeconds: 1200
     });
 
@@ -70,7 +78,7 @@ function creatClientConfig(args : any) : mqtt5.Mqtt5ClientConfig {
 
 function createClient(args: any) : mqtt5.Mqtt5Client {
 
-    let config : mqtt5.Mqtt5ClientConfig = creatClientConfig(args);
+    let config : mqtt5.Mqtt5ClientConfig = createClientConfig(args);
 
     console.log("Creating client for " + config.hostName);
     let client : mqtt5.Mqtt5Client = new mqtt5.Mqtt5Client(config);


### PR DESCRIPTION
*Issue #, if available:*

Some samples miss client ID, so an IoT broker sets it to some random value.
Discovered in this PR: https://github.com/aws/aws-iot-device-sdk-js-v2/pull/539

*Description of changes:*

Add default client ID value set to `test-<RANDOM VALUE>`. And where possible, add an option for client ID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
