### PR TITLE
Add required keepAliveIntervalSeconds in MQTT5 PubSub React sample

### DIFF
--- a/samples/browser/react_sample/src/PubSub5.tsx
+++ b/samples/browser/react_sample/src/PubSub5.tsx
@@ -77,9 +77,10 @@ function createClient(provider: AWSCognitoCredentialsProvider) : mqtt5.Mqtt5Clie
     let builder: iot.AwsIotMqtt5ClientConfigBuilder = iot.AwsIotMqtt5ClientConfigBuilder.newWebsocketMqttBuilderWithSigv4Auth(
         AWS_IOT_ENDPOINT,
         wsConfig
-    )
+    );
     builder.withConnectProperties({
-        clientId: "test-" + Math.floor(Math.random() * 100000000)
+        clientId: "test-" + Math.floor(Math.random() * 100000000),
+        keepAliveIntervalSeconds: 30 // Mandatory field added
     });
 
     let client : mqtt5.Mqtt5Client = new mqtt5.Mqtt5Client(builder.build());


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added required keepAliveIntervalSeconds parameter in the MQTT5 PubSub React sample as it's a mandatory field according to: https://github.com/awslabs/aws-crt-nodejs/blame/main/lib/common/mqtt5_packet.ts#L878

Changes made:
- Added keepAliveIntervalSeconds: 30 to the connect packet configuration in PubSub React sample
- This parameter is required as per MQTT5 specification and cannot be optional

This fixes the TypeScript compilation error:
TS2345: Argument of type '{ clientId: string; }' is not assignable to parameter of type 'ConnectPacket'.
Property 'keepAliveIntervalSeconds' is missing in type '{ clientId: string; }' but required in type 'ConnectPacket'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.