### PR TITLE
Change Github Action Schedule

### DIFF
--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -1,7 +1,7 @@
 name: HandleStaleDiscussions
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 9 * * 1' # minute hour dom month dow
   discussion_comment:
     types: [created]
 

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -3,7 +3,7 @@ name: "Close stale issues"
 # Controls when the action will run.
 on:
   schedule:
-    - cron: "*/60 * * * *"
+    - cron: '0 9 * * 1' # minute hour dom month dow
 
 jobs:
   cleanup:


### PR DESCRIPTION
Stale discussions and issues are checked and handled once a week instead hourly and 6 times a day.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
