### PR TITLE
Bump aws-crt-builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.75
+  BUILDER_VERSION: v0.9.84
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-iot-device-sdk-js-v2


### PR DESCRIPTION
*Issue #, if available:*

[Recent update](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20250830.2281)  of GitHub runner image for macOS causes CI failures.

*Description of changes:*

Updating aws-crt-builder (specifically, https://github.com/awslabs/aws-crt-builder/pull/323 is needed) resolves the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
