### PR TITLE
Add TLS 1.3 support on macOS via s2n-tls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,25 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }}
 
+  # Runs the macOS build with s2n-tls backend instead of Apple Secure Transport
+  osx-s2n-tls:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - macos-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: "1"
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} (s2n-tls)
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }}
+
   linux:
     runs-on: ubuntu-22.04 # latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The AWS IoT Device SDK for JavaScript v2 connects your JavaScript applications a
 * [Getting Started](#getting-started)
 * [Samples](samples)
 * [MQTT5 User Guide](./documents/MQTT5_Userguide.md)
+* [Specifics](#specifics)
 * [Getting Help](#getting-help)
 * [Resources](#resources)
 
@@ -58,20 +59,6 @@ npm install aws-iot-device-sdk-v2
 
 See the [Development Guide](./documents/DEVELOPING.md) for detailed instructions on building from source and using local builds.
 
-#### Mac-Only TLS Behavior
-
-By default, macOS uses Apple Secure Transport as the TLS implementation, which supports up to TLS 1.2. To enable TLS 1.3 on macOS, set the environment variable `AWS_CRT_USE_NON_FIPS_TLS_13=1` before running your application. This switches the TLS backend to s2n-tls with aws-lc at runtime.
-
-> [!IMPORTANT]
-> Enabling `AWS_CRT_USE_NON_FIPS_TLS_13` trades FIPS compliance and macOS Keychain/PKCS#12 integration for TLS 1.3 support. This variable has no effect on Linux or Windows.
-
-Please note that when using the default Apple Secure Transport backend, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically. When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
-
-```
-static: certificate has an existing certificate-key pair that was previously imported into the Keychain.
- Using key from Keychain instead of the one provided.
-```
-
 ## Getting Started
 
 To get started with the AWS IoT Device SDK for JavaScript v2:
@@ -95,6 +82,24 @@ Check out the [samples](samples) directory for working code examples that demons
 - [AWS IoT Fleet provisioning](./samples/node/service_clients/fleet_provisioning)
 
 The samples provide ready-to-run code with detailed setup instructions for each authentication method and use case.
+
+## Specifics
+
+#### Mac-Only TLS 1.3
+
+By default, macOS uses Apple Secure Transport as the TLS implementation, which supports up to TLS 1.2. To enable TLS 1.3 on macOS, set the environment variable `AWS_CRT_USE_NON_FIPS_TLS_13=1` before running your application. This switches the TLS backend to s2n-tls with aws-lc at runtime.
+
+> [!IMPORTANT]
+> Enabling `AWS_CRT_USE_NON_FIPS_TLS_13` trades FIPS compliance and macOS Keychain/PKCS#12 integration for TLS 1.3 support. This variable has no effect on Linux or Windows.
+
+#### Mac Keychain
+
+When using the default Apple Secure Transport backend, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically. When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.
+ Using key from Keychain instead of the one provided.
+```
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ npm install aws-iot-device-sdk-v2
 
 See the [Development Guide](./documents/DEVELOPING.md) for detailed instructions on building from source and using local builds.
 
+#### Mac-Only TLS Behavior
+
+By default, macOS uses Apple Secure Transport as the TLS implementation, which supports up to TLS 1.2. To enable TLS 1.3 on macOS, set the environment variable `AWS_CRT_USE_NON_FIPS_TLS_13=1` before running your application. This switches the TLS backend to s2n-tls with aws-lc at runtime.
+
+> [!IMPORTANT]
+> Enabling `AWS_CRT_USE_NON_FIPS_TLS_13` trades FIPS compliance and macOS Keychain/PKCS#12 integration for TLS 1.3 support. This variable has no effect on Linux or Windows.
+
+Please note that when using the default Apple Secure Transport backend, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically. When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.
+ Using key from Keychain instead of the one provided.
+```
+
 ## Getting Started
 
 To get started with the AWS IoT Device SDK for JavaScript v2:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2581,9 +2581,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-crt": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.31.0.tgz",
-      "integrity": "sha512-tugrMoR69vHliuCVOSbndnyWNh2We5yuN4h0i70Xh9bDYD+jxAWGqdjjd73/BY++1ZRGH9H36qsM2f8BsvP5Gw==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.32.1.tgz",
+      "integrity": "sha512-sHWj+jOEv/ujlrZxH4FyHB9+k2QkqeG46sCNvsusw3Z4G5PkD0Hh9bxWz+veQX0OxYA7ZKiuRylFRFwvZf336g==",
       "requires": {
         "@aws-sdk/util-utf8-browser": "^3.259.0",
         "@httptoolkit/websocket-stream": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@aws-sdk/util-utf8-browser": "^3.109.0",
-    "aws-crt": "1.31.0",
+    "aws-crt": "1.32.1",
     "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
Add TLS 1.3 support on macOS via s2n-tls

- Bump `awscrt` to 1.32.1, which adds runtime support for switching to s2n-tls on macOS
- Document the `AWS_CRT_USE_NON_FIPS_TLS_13` environment variable in the README
- Add `osx-s2n-tls` CI job to exercise the s2n-tls backend on macOS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
