### PR TITLE
Prevent script injection in GHA workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.84
+  BUILDER_VERSION: v0.9.95
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-iot-device-sdk-js-v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,15 @@ jobs:
 
     - name: Make new release
       env:
-        Title: ${{ github.event.inputs.release_title }}
-        ReleaseType: ${{ github.event.inputs.release_type }}
+        TITLE: ${{ github.event.inputs.release_title }}
+        RELEASE_TYPE: ${{ github.event.inputs.release_type }}
       run: |
         # Escape special characters
-        Title=$(echo ${Title//[\"]\\\"})
-        Title=$(echo ${Title//[\']\\\'})
-        Title=$(echo ${Title//[\$]})
+        TITLE=$(echo ${TITLE//[\"]\\\"})
+        TITLE=$(echo ${TITLE//[\']\\\'})
+        TITLE=$(echo ${TITLE//[\$]})
 
-        ./utils/publish-release.sh "$ReleaseType" "$Title"
+        ./utils/publish-release.sh "$RELEASE_TYPE" "$TITLE"
 
     - name: Generate documentation.
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,14 @@ jobs:
     - name: Make new release
       env:
         Title: ${{ github.event.inputs.release_title }}
+        ReleaseType: ${{ github.event.inputs.release_type }}
       run: |
         # Escape special characters
         Title=$(echo ${Title//[\"]\\\"})
         Title=$(echo ${Title//[\']\\\'})
         Title=$(echo ${Title//[\$]})
 
-        ./utils/publish-release.sh "${{ github.event.inputs.release_type }}" "$Title"
+        ./utils/publish-release.sh "$ReleaseType" "$Title"
 
     - name: Generate documentation.
       run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move untrusted github.event.* interpolations out of run: blocks and into env: variables, then reference via "$VAR" inside the shell script. Eliminates script-injection sinks flagged by AppSec.

Affected workflows:
release.yml (release.tag_type)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
