### PR TITLE
Redact sensitive fields in Greengrass IPC

### DIFF
--- a/lib/eventstream_rpc_utils.ts
+++ b/lib/eventstream_rpc_utils.ts
@@ -5,6 +5,7 @@
 
 import * as eventstream_rpc from "./eventstream_rpc";
 import {CrtError, eventstream} from "aws-crt";
+import * as util from "util";
 
 /*
  * Internal utility functions for generated RPC clients to perform normalization, serialization, deserialization, and
@@ -85,6 +86,42 @@ export function setDefinedProperty(object: any, propertyName: string, value: any
     } else {
         object[propertyName] = value;
     }
+}
+
+/**
+ * Value used to replace sensitive property values in log/inspect output.
+ */
+const SENSITIVE_DATA_PLACEHOLDER : string = "*** REDACTED ***";
+
+/**
+ * Attaches a non-enumerable custom-inspect hook so that sensitive properties are redacted.
+ *
+ * @param value object whose sensitive fields should be redacted when logged
+ * @param sensitiveProperties names of the properties to redact
+ *
+ * @return the same object, to allow call chaining
+ */
+export function applySensitiveDataRedaction(value: any, sensitiveProperties: string[]) : any {
+    if (value === undefined || value === null) {
+        return value;
+    }
+
+    Object.defineProperty(value, util.inspect.custom, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () {
+            const redacted : any = { ...this };
+            for (const propertyName of sensitiveProperties) {
+                if (redacted[propertyName] !== undefined) {
+                    redacted[propertyName] = SENSITIVE_DATA_PLACEHOLDER;
+                }
+            }
+            return redacted;
+        }
+    });
+
+    return value;
 }
 
 /**

--- a/lib/eventstream_rpc_utils.ts
+++ b/lib/eventstream_rpc_utils.ts
@@ -94,7 +94,12 @@ export function setDefinedProperty(object: any, propertyName: string, value: any
 const SENSITIVE_DATA_PLACEHOLDER : string = "*** REDACTED ***";
 
 /**
- * Attaches a non-enumerable custom-inspect hook so that sensitive properties are redacted.
+ * Attaches non-enumerable hooks so that sensitive properties are redacted from
+ * console.log / util.inspect output and from JSON.stringify output.  The underlying
+ * data is left untouched, so direct field access is unaffected.
+ *
+ * This is the Javascript analogue of the redacted toString()/__repr__() emitted by the
+ * Java and Python event-stream RPC generators for shapes with @sensitive members.
  *
  * @param value object whose sensitive fields should be redacted when logged
  * @param sensitiveProperties names of the properties to redact
@@ -106,19 +111,30 @@ export function applySensitiveDataRedaction(value: any, sensitiveProperties: str
         return value;
     }
 
+    const redactor = function (this: any) {
+        const redacted : any = { ...this };
+        for (const propertyName of sensitiveProperties) {
+            if (redacted[propertyName] !== undefined) {
+                redacted[propertyName] = SENSITIVE_DATA_PLACEHOLDER;
+            }
+        }
+        return redacted;
+    };
+
+    // Redacts output of console.log / util.inspect
     Object.defineProperty(value, util.inspect.custom, {
         enumerable: false,
         configurable: true,
         writable: true,
-        value: function () {
-            const redacted : any = { ...this };
-            for (const propertyName of sensitiveProperties) {
-                if (redacted[propertyName] !== undefined) {
-                    redacted[propertyName] = SENSITIVE_DATA_PLACEHOLDER;
-                }
-            }
-            return redacted;
-        }
+        value: redactor
+    });
+
+    // Redacts output of JSON.stringify
+    Object.defineProperty(value, 'toJSON', {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: redactor
     });
 
     return value;

--- a/lib/greengrasscoreipc/client.ts
+++ b/lib/greengrasscoreipc/client.ts
@@ -715,6 +715,35 @@ export class Client extends EventEmitter {
     }
 
     /**
+     * Creates a SubscribeToIoTCoreConnectionStatus streaming operation.
+     *
+     * Subscribe to the connection status of the IoT Core MQTT connection.
+     *
+     * Once created, the streaming operation must be started by a call to activate().
+     *
+     * If the operation allows for streaming input, the user may attach event listeners to receive messages.
+     *
+     * If the operation allows for streaming output, the user may call sendProtocolMessage() to send messages on
+     * the operation's event stream once the operation has been activated.
+     *
+     * The user should close() a streaming operation once finished with it.  If close() is not called, the native
+     * resources associated with the streaming operation will not be freed until the client is closed.
+     *
+     * @param request data describing the SubscribeToIoTCoreConnectionStatus streaming operation to create
+     * @param options additional eventstream options to use while this operation is active
+     * @return a new StreamingOperation object
+     */
+    subscribeToIoTCoreConnectionStatus(request : model.SubscribeToIoTCoreConnectionStatusRequest, options?: eventstream_rpc.OperationOptions) : eventstream_rpc.StreamingOperation<model.SubscribeToIoTCoreConnectionStatusRequest, model.SubscribeToIoTCoreConnectionStatusResponse, void, model.IoTCoreConnectionStatusEvent> {
+        let operationConfig = {
+            name: "aws.greengrass#SubscribeToIoTCoreConnectionStatus",
+            client: this.rpcClient,
+            options: (options) ? options : {}
+        };
+
+        return new eventstream_rpc.StreamingOperation<model.SubscribeToIoTCoreConnectionStatusRequest, model.SubscribeToIoTCoreConnectionStatusResponse, void, model.IoTCoreConnectionStatusEvent>(request, operationConfig, this.serviceModel);
+    }
+
+    /**
      * Creates a SubscribeToTopic streaming operation.
      *
      * Creates a subscription for a custom topic

--- a/lib/greengrasscoreipc/model.ts
+++ b/lib/greengrasscoreipc/model.ts
@@ -96,6 +96,17 @@ export enum DeploymentStatus {
 /**
  * To preserve backwards compatibility, no validation is performed on enum-valued fields.
  */
+export enum ConnectionStatus {
+
+    CONNECTED = "CONNECTED",
+
+    DISCONNECTED = "DISCONNECTED"
+
+}
+
+/**
+ * To preserve backwards compatibility, no validation is performed on enum-valued fields.
+ */
 export enum LifecycleState {
 
     RUNNING = "RUNNING",
@@ -233,6 +244,15 @@ export enum ConfigurationValidityStatus {
     ACCEPTED = "ACCEPTED",
 
     REJECTED = "REJECTED"
+
+}
+
+export interface ConnectionStatusEvent {
+
+    /**
+     * The connection status.
+     */
+    status: ConnectionStatus
 
 }
 
@@ -509,6 +529,15 @@ export interface ConfigurationValidityReport {
      * (Optional) A message that reports why the configuration isn't valid.
      */
     message?: string
+
+}
+
+export interface IoTCoreConnectionStatusEvent {
+
+    /**
+     * The connection status event.
+     */
+    connectionStatusEvent?: ConnectionStatusEvent
 
 }
 
@@ -1052,6 +1081,14 @@ export interface GetThingShadowRequest {
      * The name of the shadow. To specify the thing's classic shadow, set this parameter to an empty string ("").
      */
     shadowName?: string
+
+}
+
+export interface SubscribeToIoTCoreConnectionStatusResponse {
+
+}
+
+export interface SubscribeToIoTCoreConnectionStatusRequest {
 
 }
 

--- a/lib/greengrasscoreipc/model_utils.ts
+++ b/lib/greengrasscoreipc/model_utils.ts
@@ -21,6 +21,7 @@ function createNormalizerMap() : Map<string, eventstream_rpc.ShapeNormalizer> {
         ["aws.greengrass#LocalDeployment", normalizeLocalDeployment],
         ["aws.greengrass#PostComponentUpdateEvent", normalizePostComponentUpdateEvent],
         ["aws.greengrass#PreComponentUpdateEvent", normalizePreComponentUpdateEvent],
+        ["aws.greengrass#ConnectionStatusEvent", normalizeConnectionStatusEvent],
         ["aws.greengrass#ComponentDetails", normalizeComponentDetails],
         ["aws.greengrass#CertificateUpdate", normalizeCertificateUpdate],
         ["aws.greengrass#BinaryMessage", normalizeBinaryMessage],
@@ -33,6 +34,7 @@ function createNormalizerMap() : Map<string, eventstream_rpc.ShapeNormalizer> {
         ["aws.greengrass#ComponentUpdatePolicyEvents", normalizeComponentUpdatePolicyEvents],
         ["aws.greengrass#SecretValue", normalizeSecretValue],
         ["aws.greengrass#ConfigurationValidityReport", normalizeConfigurationValidityReport],
+        ["aws.greengrass#IoTCoreConnectionStatusEvent", normalizeIoTCoreConnectionStatusEvent],
         ["aws.greengrass#ClientDeviceCredential", normalizeClientDeviceCredential],
         ["aws.greengrass#CertificateUpdateEvent", normalizeCertificateUpdateEvent],
         ["aws.greengrass#CertificateOptions", normalizeCertificateOptions],
@@ -84,6 +86,8 @@ function createNormalizerMap() : Map<string, eventstream_rpc.ShapeNormalizer> {
         ["aws.greengrass#SendConfigurationValidityReportRequest", normalizeSendConfigurationValidityReportRequest],
         ["aws.greengrass#GetThingShadowResponse", normalizeGetThingShadowResponse],
         ["aws.greengrass#GetThingShadowRequest", normalizeGetThingShadowRequest],
+        ["aws.greengrass#SubscribeToIoTCoreConnectionStatusResponse", normalizeSubscribeToIoTCoreConnectionStatusResponse],
+        ["aws.greengrass#SubscribeToIoTCoreConnectionStatusRequest", normalizeSubscribeToIoTCoreConnectionStatusRequest],
         ["aws.greengrass#CreateDebugPasswordResponse", normalizeCreateDebugPasswordResponse],
         ["aws.greengrass#CreateDebugPasswordRequest", normalizeCreateDebugPasswordRequest],
         ["aws.greengrass#ListComponentsResponse", normalizeListComponentsResponse],
@@ -135,6 +139,7 @@ function createValidatorMap() : Map<string, eventstream_rpc.ShapeValidator> {
         ["aws.greengrass#LocalDeployment", validateLocalDeployment],
         ["aws.greengrass#PostComponentUpdateEvent", validatePostComponentUpdateEvent],
         ["aws.greengrass#PreComponentUpdateEvent", validatePreComponentUpdateEvent],
+        ["aws.greengrass#ConnectionStatusEvent", validateConnectionStatusEvent],
         ["aws.greengrass#ComponentDetails", validateComponentDetails],
         ["aws.greengrass#CertificateUpdate", validateCertificateUpdate],
         ["aws.greengrass#BinaryMessage", validateBinaryMessage],
@@ -147,6 +152,7 @@ function createValidatorMap() : Map<string, eventstream_rpc.ShapeValidator> {
         ["aws.greengrass#ComponentUpdatePolicyEvents", validateComponentUpdatePolicyEvents],
         ["aws.greengrass#SecretValue", validateSecretValue],
         ["aws.greengrass#ConfigurationValidityReport", validateConfigurationValidityReport],
+        ["aws.greengrass#IoTCoreConnectionStatusEvent", validateIoTCoreConnectionStatusEvent],
         ["aws.greengrass#ClientDeviceCredential", validateClientDeviceCredential],
         ["aws.greengrass#CertificateUpdateEvent", validateCertificateUpdateEvent],
         ["aws.greengrass#CertificateOptions", validateCertificateOptions],
@@ -198,6 +204,8 @@ function createValidatorMap() : Map<string, eventstream_rpc.ShapeValidator> {
         ["aws.greengrass#SendConfigurationValidityReportRequest", validateSendConfigurationValidityReportRequest],
         ["aws.greengrass#GetThingShadowResponse", validateGetThingShadowResponse],
         ["aws.greengrass#GetThingShadowRequest", validateGetThingShadowRequest],
+        ["aws.greengrass#SubscribeToIoTCoreConnectionStatusResponse", validateSubscribeToIoTCoreConnectionStatusResponse],
+        ["aws.greengrass#SubscribeToIoTCoreConnectionStatusRequest", validateSubscribeToIoTCoreConnectionStatusRequest],
         ["aws.greengrass#CreateDebugPasswordResponse", validateCreateDebugPasswordResponse],
         ["aws.greengrass#CreateDebugPasswordRequest", validateCreateDebugPasswordRequest],
         ["aws.greengrass#ListComponentsResponse", validateListComponentsResponse],
@@ -244,6 +252,7 @@ function createDeserializerMap() : Map<string, eventstream_rpc.ShapeDeserializer
         ["aws.greengrass#ConflictError", deserializeEventstreamMessageToConflictError],
         ["aws.greengrass#CreateDebugPasswordResponse", deserializeEventstreamMessageToCreateDebugPasswordResponse],
         ["aws.greengrass#SubscriptionResponseMessage", deserializeEventstreamMessageToSubscriptionResponseMessage],
+        ["aws.greengrass#SubscribeToIoTCoreConnectionStatusResponse", deserializeEventstreamMessageToSubscribeToIoTCoreConnectionStatusResponse],
         ["aws.greengrass#FailedUpdateConditionCheckError", deserializeEventstreamMessageToFailedUpdateConditionCheckError],
         ["aws.greengrass#ListNamedShadowsForThingResponse", deserializeEventstreamMessageToListNamedShadowsForThingResponse],
         ["aws.greengrass#ComponentNotFoundError", deserializeEventstreamMessageToComponentNotFoundError],
@@ -274,6 +283,7 @@ function createDeserializerMap() : Map<string, eventstream_rpc.ShapeDeserializer
         ["aws.greengrass#GetClientDeviceAuthTokenResponse", deserializeEventstreamMessageToGetClientDeviceAuthTokenResponse],
         ["aws.greengrass#CreateLocalDeploymentResponse", deserializeEventstreamMessageToCreateLocalDeploymentResponse],
         ["aws.greengrass#PublishToTopicResponse", deserializeEventstreamMessageToPublishToTopicResponse],
+        ["aws.greengrass#IoTCoreConnectionStatusEvent", deserializeEventstreamMessageToIoTCoreConnectionStatusEvent],
         ["aws.greengrass#ValidateAuthorizationTokenResponse", deserializeEventstreamMessageToValidateAuthorizationTokenResponse],
         ["aws.greengrass#UpdateThingShadowResponse", deserializeEventstreamMessageToUpdateThingShadowResponse],
         ["aws.greengrass#AuthorizeClientDeviceActionResponse", deserializeEventstreamMessageToAuthorizeClientDeviceActionResponse],
@@ -301,6 +311,7 @@ function createSerializerMap() : Map<string, eventstream_rpc.ShapeSerializer> {
         ["aws.greengrass#GetComponentDetailsRequest", serializeGetComponentDetailsRequestToEventstreamMessage],
         ["aws.greengrass#PublishToTopicRequest", serializePublishToTopicRequestToEventstreamMessage],
         ["aws.greengrass#CreateDebugPasswordRequest", serializeCreateDebugPasswordRequestToEventstreamMessage],
+        ["aws.greengrass#SubscribeToIoTCoreConnectionStatusRequest", serializeSubscribeToIoTCoreConnectionStatusRequestToEventstreamMessage],
         ["aws.greengrass#UpdateThingShadowRequest", serializeUpdateThingShadowRequestToEventstreamMessage],
         ["aws.greengrass#ResumeComponentRequest", serializeResumeComponentRequestToEventstreamMessage],
         ["aws.greengrass#StopComponentRequest", serializeStopComponentRequestToEventstreamMessage],
@@ -577,6 +588,14 @@ function createOperationMap() : Map<string, eventstream_rpc.EventstreamRpcServic
                 "aws.greengrass#UnauthorizedError"
             ])
         }],
+        ["aws.greengrass#SubscribeToIoTCoreConnectionStatus", {
+            requestShape: "aws.greengrass#SubscribeToIoTCoreConnectionStatusRequest",
+            responseShape: "aws.greengrass#SubscribeToIoTCoreConnectionStatusResponse",
+            inboundMessageShape: "aws.greengrass#IoTCoreConnectionStatusEvent",
+            errorShapes: new Set<string>([
+                "aws.greengrass#ServiceError"
+            ])
+        }],
         ["aws.greengrass#SubscribeToTopic", {
             requestShape: "aws.greengrass#SubscribeToTopicRequest",
             responseShape: "aws.greengrass#SubscribeToTopicResponse",
@@ -661,6 +680,11 @@ const DeploymentStatusValues : Set<string> = new Set<string>([
     "CANCELED"
 ]);
 
+const ConnectionStatusValues : Set<string> = new Set<string>([
+    "CONNECTED",
+    "DISCONNECTED"
+]);
+
 const LifecycleStateValues : Set<string> = new Set<string>([
     "RUNNING",
     "ERRORED",
@@ -725,6 +749,7 @@ function createEnumsMap() : Map<string, Set<string>> {
     return new Map<string, Set<string>>([
         ["DetailedDeploymentStatus", DetailedDeploymentStatusValues],
         ["DeploymentStatus", DeploymentStatusValues],
+        ["ConnectionStatus", ConnectionStatusValues],
         ["LifecycleState", LifecycleStateValues],
         ["MetricUnitType", MetricUnitTypeValues],
         ["PayloadFormat", PayloadFormatValues],
@@ -816,6 +841,13 @@ export function normalizePreComponentUpdateEvent(value : model.PreComponentUpdat
     return normalizedValue;
 }
 
+export function normalizeConnectionStatusEvent(value : model.ConnectionStatusEvent) : any {
+    let normalizedValue : any = {};
+    eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'status', value.status);
+
+    return normalizedValue;
+}
+
 export function normalizeComponentDetails(value : model.ComponentDetails) : any {
     let normalizedValue : any = {};
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'componentName', value.componentName);
@@ -832,6 +864,7 @@ export function normalizeCertificateUpdate(value : model.CertificateUpdate) : an
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'publicKey', value.publicKey);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'certificate', value.certificate);
     eventstream_rpc_utils.setDefinedArrayProperty(normalizedValue, 'caCertificates', value.caCertificates, undefined);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['privateKey', 'publicKey', 'certificate', 'caCertificates']);
 
     return normalizedValue;
 }
@@ -858,6 +891,7 @@ export function normalizeMQTTCredential(value : model.MQTTCredential) : any {
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'certificatePem', value.certificatePem);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'username', value.username);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'password', value.password);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['password']);
 
     return normalizedValue;
 }
@@ -914,6 +948,7 @@ export function normalizeSecretValue(value : model.SecretValue) : any {
     let normalizedValue : any = {};
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'secretString', value.secretString);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'secretBinary', value.secretBinary, eventstream_rpc_utils.encodePayloadAsString);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['secretString', 'secretBinary']);
 
     return normalizedValue;
 }
@@ -923,6 +958,13 @@ export function normalizeConfigurationValidityReport(value : model.Configuration
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'status', value.status);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'deploymentId', value.deploymentId);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'message', value.message);
+
+    return normalizedValue;
+}
+
+export function normalizeIoTCoreConnectionStatusEvent(value : model.IoTCoreConnectionStatusEvent) : any {
+    let normalizedValue : any = {};
+    eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'connectionStatusEvent', value.connectionStatusEvent, normalizeConnectionStatusEvent);
 
     return normalizedValue;
 }
@@ -937,6 +979,7 @@ export function normalizeClientDeviceCredential(value : model.ClientDeviceCreden
 export function normalizeCertificateUpdateEvent(value : model.CertificateUpdateEvent) : any {
     let normalizedValue : any = {};
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'certificateUpdate', value.certificateUpdate, normalizeCertificateUpdate);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['certificateUpdate']);
 
     return normalizedValue;
 }
@@ -1169,6 +1212,7 @@ export function normalizeGetSecretValueResponse(value : model.GetSecretValueResp
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'versionId', value.versionId);
     eventstream_rpc_utils.setDefinedArrayProperty(normalizedValue, 'versionStage', value.versionStage, undefined);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'secretValue', value.secretValue, normalizeSecretValue);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['secretValue']);
 
     return normalizedValue;
 }
@@ -1306,6 +1350,18 @@ export function normalizeGetThingShadowRequest(value : model.GetThingShadowReque
     return normalizedValue;
 }
 
+export function normalizeSubscribeToIoTCoreConnectionStatusResponse(value : model.SubscribeToIoTCoreConnectionStatusResponse) : any {
+    let normalizedValue : any = {};
+
+    return normalizedValue;
+}
+
+export function normalizeSubscribeToIoTCoreConnectionStatusRequest(value : model.SubscribeToIoTCoreConnectionStatusRequest) : any {
+    let normalizedValue : any = {};
+
+    return normalizedValue;
+}
+
 export function normalizeCreateDebugPasswordResponse(value : model.CreateDebugPasswordResponse) : any {
     let normalizedValue : any = {};
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'password', value.password);
@@ -1313,6 +1369,7 @@ export function normalizeCreateDebugPasswordResponse(value : model.CreateDebugPa
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'passwordExpiration', value.passwordExpiration, eventstream_rpc_utils.encodeDateAsNumber);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'certificateSHA256Hash', value.certificateSHA256Hash);
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'certificateSHA1Hash', value.certificateSHA1Hash);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['password']);
 
     return normalizedValue;
 }
@@ -1410,6 +1467,7 @@ export function normalizeInvalidCredentialError(value : model.InvalidCredentialE
 export function normalizeGetClientDeviceAuthTokenResponse(value : model.GetClientDeviceAuthTokenResponse) : any {
     let normalizedValue : any = {};
     eventstream_rpc_utils.setDefinedProperty(normalizedValue, 'clientDeviceAuthToken', value.clientDeviceAuthToken);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['clientDeviceAuthToken']);
 
     return normalizedValue;
 }
@@ -1627,6 +1685,10 @@ export function validatePreComponentUpdateEvent(value : model.PreComponentUpdate
     eventstream_rpc_utils.validateValueAsBoolean(value.isGgcRestarting, 'isGgcRestarting', 'PreComponentUpdateEvent');
 }
 
+export function validateConnectionStatusEvent(value : model.ConnectionStatusEvent) : void {
+    eventstream_rpc_utils.validateValueAsString(value.status, 'status', 'ConnectionStatusEvent');
+}
+
 export function validateComponentDetails(value : model.ComponentDetails) : void {
     eventstream_rpc_utils.validateValueAsString(value.componentName, 'componentName', 'ComponentDetails');
     eventstream_rpc_utils.validateValueAsString(value.version, 'version', 'ComponentDetails');
@@ -1708,6 +1770,14 @@ export function validateConfigurationValidityReport(value : model.ConfigurationV
     eventstream_rpc_utils.validateValueAsString(value.status, 'status', 'ConfigurationValidityReport');
     eventstream_rpc_utils.validateValueAsString(value.deploymentId, 'deploymentId', 'ConfigurationValidityReport');
     eventstream_rpc_utils.validateValueAsOptionalString(value.message, 'message', 'ConfigurationValidityReport');
+}
+
+const _IoTCoreConnectionStatusEventPropertyValidators : Map<string, eventstream_rpc_utils.ElementValidator> = new Map<string, eventstream_rpc_utils.ElementValidator>([
+    ["connectionStatusEvent", validateConnectionStatusEvent]
+]);
+
+export function validateIoTCoreConnectionStatusEvent(value : model.IoTCoreConnectionStatusEvent) : void {
+    eventstream_rpc_utils.validateValueAsUnion(value, _IoTCoreConnectionStatusEventPropertyValidators);
 }
 
 const _ClientDeviceCredentialPropertyValidators : Map<string, eventstream_rpc_utils.ElementValidator> = new Map<string, eventstream_rpc_utils.ElementValidator>([
@@ -1968,6 +2038,12 @@ export function validateGetThingShadowRequest(value : model.GetThingShadowReques
     eventstream_rpc_utils.validateValueAsOptionalString(value.shadowName, 'shadowName', 'GetThingShadowRequest');
 }
 
+export function validateSubscribeToIoTCoreConnectionStatusResponse(value : model.SubscribeToIoTCoreConnectionStatusResponse) : void {
+}
+
+export function validateSubscribeToIoTCoreConnectionStatusRequest(value : model.SubscribeToIoTCoreConnectionStatusRequest) : void {
+}
+
 export function validateCreateDebugPasswordResponse(value : model.CreateDebugPasswordResponse) : void {
     eventstream_rpc_utils.validateValueAsString(value.password, 'password', 'CreateDebugPasswordResponse');
     eventstream_rpc_utils.validateValueAsString(value.username, 'username', 'CreateDebugPasswordResponse');
@@ -2166,11 +2242,16 @@ export function deserializePreComponentUpdateEvent(value : model.PreComponentUpd
     return value;
 }
 
+export function deserializeConnectionStatusEvent(value : model.ConnectionStatusEvent) : model.ConnectionStatusEvent {
+    return value;
+}
+
 export function deserializeComponentDetails(value : model.ComponentDetails) : model.ComponentDetails {
     return value;
 }
 
 export function deserializeCertificateUpdate(value : model.CertificateUpdate) : model.CertificateUpdate {
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['privateKey', 'publicKey', 'certificate', 'caCertificates']);
     return value;
 }
 
@@ -2186,6 +2267,7 @@ export function deserializeJsonMessage(value : model.JsonMessage) : model.JsonMe
 }
 
 export function deserializeMQTTCredential(value : model.MQTTCredential) : model.MQTTCredential {
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['password']);
     return value;
 }
 
@@ -2216,10 +2298,16 @@ export function deserializeComponentUpdatePolicyEvents(value : model.ComponentUp
 
 export function deserializeSecretValue(value : model.SecretValue) : model.SecretValue {
     eventstream_rpc_utils.setDefinedProperty(value, 'secretBinary', value.secretBinary, eventstream_rpc_utils.transformStringAsPayload);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['secretString', 'secretBinary']);
     return value;
 }
 
 export function deserializeConfigurationValidityReport(value : model.ConfigurationValidityReport) : model.ConfigurationValidityReport {
+    return value;
+}
+
+export function deserializeIoTCoreConnectionStatusEvent(value : model.IoTCoreConnectionStatusEvent) : model.IoTCoreConnectionStatusEvent {
+    eventstream_rpc_utils.setDefinedProperty(value, 'connectionStatusEvent', value.connectionStatusEvent, deserializeConnectionStatusEvent);
     return value;
 }
 
@@ -2229,6 +2317,7 @@ export function deserializeClientDeviceCredential(value : model.ClientDeviceCred
 
 export function deserializeCertificateUpdateEvent(value : model.CertificateUpdateEvent) : model.CertificateUpdateEvent {
     eventstream_rpc_utils.setDefinedProperty(value, 'certificateUpdate', value.certificateUpdate, deserializeCertificateUpdate);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['certificateUpdate']);
     return value;
 }
 
@@ -2365,6 +2454,7 @@ export function deserializeUpdateStateRequest(value : model.UpdateStateRequest) 
 
 export function deserializeGetSecretValueResponse(value : model.GetSecretValueResponse) : model.GetSecretValueResponse {
     eventstream_rpc_utils.setDefinedProperty(value, 'secretValue', value.secretValue, deserializeSecretValue);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['secretValue']);
     return value;
 }
 
@@ -2446,8 +2536,17 @@ export function deserializeGetThingShadowRequest(value : model.GetThingShadowReq
     return value;
 }
 
+export function deserializeSubscribeToIoTCoreConnectionStatusResponse(value : model.SubscribeToIoTCoreConnectionStatusResponse) : model.SubscribeToIoTCoreConnectionStatusResponse {
+    return value;
+}
+
+export function deserializeSubscribeToIoTCoreConnectionStatusRequest(value : model.SubscribeToIoTCoreConnectionStatusRequest) : model.SubscribeToIoTCoreConnectionStatusRequest {
+    return value;
+}
+
 export function deserializeCreateDebugPasswordResponse(value : model.CreateDebugPasswordResponse) : model.CreateDebugPasswordResponse {
     eventstream_rpc_utils.setDefinedProperty(value, 'passwordExpiration', value.passwordExpiration, eventstream_rpc_utils.transformNumberAsDate);
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['password']);
     return value;
 }
 
@@ -2508,6 +2607,7 @@ export function deserializeInvalidCredentialError(value : model.InvalidCredentia
 }
 
 export function deserializeGetClientDeviceAuthTokenResponse(value : model.GetClientDeviceAuthTokenResponse) : model.GetClientDeviceAuthTokenResponse {
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, ['clientDeviceAuthToken']);
     return value;
 }
 
@@ -2629,6 +2729,13 @@ export function deserializeEventstreamMessageToSubscriptionResponseMessage(messa
     let response : model.SubscriptionResponseMessage = JSON.parse(payload_text) as model.SubscriptionResponseMessage;
 
     return deserializeSubscriptionResponseMessage(response);
+}
+
+export function deserializeEventstreamMessageToSubscribeToIoTCoreConnectionStatusResponse(message: eventstream.Message) : model.SubscribeToIoTCoreConnectionStatusResponse {
+    const payload_text : string = toUtf8(new Uint8Array(message.payload as ArrayBuffer));
+    let response : model.SubscribeToIoTCoreConnectionStatusResponse = JSON.parse(payload_text) as model.SubscribeToIoTCoreConnectionStatusResponse;
+
+    return deserializeSubscribeToIoTCoreConnectionStatusResponse(response);
 }
 
 export function deserializeEventstreamMessageToFailedUpdateConditionCheckError(message: eventstream.Message) : model.FailedUpdateConditionCheckError {
@@ -2841,6 +2948,13 @@ export function deserializeEventstreamMessageToPublishToTopicResponse(message: e
     return deserializePublishToTopicResponse(response);
 }
 
+export function deserializeEventstreamMessageToIoTCoreConnectionStatusEvent(message: eventstream.Message) : model.IoTCoreConnectionStatusEvent {
+    const payload_text : string = toUtf8(new Uint8Array(message.payload as ArrayBuffer));
+    let response : model.IoTCoreConnectionStatusEvent = JSON.parse(payload_text) as model.IoTCoreConnectionStatusEvent;
+
+    return deserializeIoTCoreConnectionStatusEvent(response);
+}
+
 export function deserializeEventstreamMessageToValidateAuthorizationTokenResponse(message: eventstream.Message) : model.ValidateAuthorizationTokenResponse {
     const payload_text : string = toUtf8(new Uint8Array(message.payload as ArrayBuffer));
     let response : model.ValidateAuthorizationTokenResponse = JSON.parse(payload_text) as model.ValidateAuthorizationTokenResponse;
@@ -2992,6 +3106,13 @@ export function serializeCreateDebugPasswordRequestToEventstreamMessage(request 
     return {
         type: eventstream.MessageType.ApplicationMessage,
         payload: JSON.stringify(normalizeCreateDebugPasswordRequest(request))
+    };
+}
+
+export function serializeSubscribeToIoTCoreConnectionStatusRequestToEventstreamMessage(request : model.SubscribeToIoTCoreConnectionStatusRequest) : eventstream.Message {
+    return {
+        type: eventstream.MessageType.ApplicationMessage,
+        payload: JSON.stringify(normalizeSubscribeToIoTCoreConnectionStatusRequest(request))
     };
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Sensitive fields (passwords, tokens, private keys) in Greengrass IPC model objects are now automatically redacted when logged via console.log() or JSON.stringify().
- Related to : https://github.com/awslabs/smithy-iot-device-sdk-greengrass-ipc/pull/24
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
