### PR TITLE
[Do Not Merge]: Emit Warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: latest
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: higher_node_version
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-iot-device-sdk-js-v2
   LINUX_BASE_IMAGE: ubuntu-16-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: higher_node_version
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: latest
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-iot-device-sdk-js-v2
   LINUX_BASE_IMAGE: ubuntu-16-x64

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 The AWS IoT Device SDK for JavaScript v2 connects your JavaScript applications and devices to the AWS IoT platform. It handles the complexities of secure communication, authentication, and device management so you can focus on your IoT solution. The SDK makes it easy to use AWS IoT services like Device Shadows, Jobs, and Fleet Provisioning.
 
+> [!IMPORTANT]
+> **Starting January 2027**, the AWS IoT Device SDK for JavaScript v2 (IoT SDK JS V2) will require **Node.js 22.x or later**.
+> Support for Node.js 14.x, 16.x, 18.x, and 20.x will be dropped.
+>
+> To continue receiving updates for AWS IoT Device SDK for JavaScript v2, bug fixes, and security updates, please upgrade to a supported version of Node.js (ideally the latest LTS).
+>
+
 **Supported Platforms**: Linux, Windows 11+, macOS 14+
 
 > **Note**: The SDK is known to work on older platform versions, but we only guarantee compatibility for the platforms listed above.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -61,7 +61,7 @@ export {
 
 /**
  * Emit runtime deprecation warning when running on a Node.js version
- * that aws-crt will stop supporting (Node.js < 22).
+ * that iot-sdk-js-v2 will stop supporting (Node.js < 22).
  */
 (function warnUnsupportedNodeVersion () {
     if(typeof process !== 'object' ||

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,6 +14,7 @@
  * @packageDocumentation
  */
 
+import './suppress_crt_node_warning';
 import * as eventstream_rpc from './eventstream_rpc';
 import * as greengrass from './greengrass/discoveryclient';
 import * as greengrasscoreipc from './greengrasscoreipc';
@@ -57,3 +58,30 @@ export {
     CrtError,
     ICrtError
 }
+
+/**
+ * Emit runtime deprecation warning when running on a Node.js version
+ * that aws-crt will stop supporting (Node.js < 22).
+ */
+(function warnUnsupportedNodeVersion () {
+    if(typeof process !== 'object' ||
+       typeof process.versions !== 'object' ||
+       typeof process.versions.node === 'undefined' ||
+       typeof process.emitWarning !== 'function'){
+        return;
+    }
+    const nodeVersion = process.versions.node
+    const parsedNodeVersion = parseInt(nodeVersion.split('.')[0],10);
+    if(Number.isNaN(parsedNodeVersion) || parsedNodeVersion >= 22){
+        return;
+    }
+    process.emitWarning(
+        `\n\nStarting from January 2027, the AWS IoT Device SDK for JavaScript v2 (IoT SDK JS V2) will require Node.js 22.x or later.\n` +
+        `Support for Node.js 14.x, 16.x, 18.x and 20.x will be dropped.\n\n` +
+        `You are currently on Node.js v${nodeVersion}.\n\n`+
+        `To continue receiving updates for AWS IoT Device SDK for JavaScript v2, bug fixes, and security updates, `+
+        `please upgrade to a supported version of Node.js (ideally the latest LTS).\n\n`+
+        `More information: https://github.com/aws/aws-iot-device-sdk-js-v2`,
+        'NodeDeprecationWarning'
+    );
+})();

--- a/lib/suppress_crt_node_warning.ts
+++ b/lib/suppress_crt_node_warning.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+// Imported before 'aws-crt' so this SDK owns the single Node.js deprecation
+(globalThis as any).AWS_CRT_NODEJS_SUPPRESS_NODE_DEPRECATION_WARNING = true;


### PR DESCRIPTION
*Description of changes:*
- Disable `aws-crt-nodejs` deprecation warning.
- Till January 2027, customer using `iot-device-sdk-js-v2` will get warning on import on using Node.js version that is not LTS.
- The warning is emitted on sdk import

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
